### PR TITLE
add github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: File a bug report
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**User Impact**
+A description of the impact of this bug on an end-user (or your own work).
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+## Why was this change made?
+
+
+
+## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?


### PR DESCRIPTION
## Why was this change made?

To add github templates for PRs and bugs. 

Fixes #44

## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?

n/a