### PR TITLE
Add JWT token authentication for the technical_metadata path

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,7 @@ Metrics/BlockLength:
 Style/Documentation:
   Exclude:
     - 'spec/**/*'
+    - 'app/controllers/application_controller.rb'
     - 'app/mailers/application_mailer.rb'
     - 'app/models/application_record.rb'
     - 'config/application.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'rails', '~> 6.0.2', '>= 6.0.2.1'
 gem 'committee' # validates Open API spec (OAS)
 gem 'config'
 gem 'honeybadger'
+gem 'jwt'
 gem 'okcomputer'
 gem 'pg'
 gem 'sidekiq', '~> 5.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,7 @@ GEM
     jaro_winkler (1.5.4)
     json (2.3.0)
     json_schema (0.20.8)
+    jwt (2.2.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -321,6 +322,7 @@ DEPENDENCIES
   dlss-capistrano
   dor-workflow-client (~> 3.17)
   honeybadger
+  jwt
   listen (>= 3.0.5, < 3.2)
   okcomputer
   pg

--- a/README.md
+++ b/README.md
@@ -62,10 +62,16 @@ $ rails c
 > client.create_workflow_by_name('druid:bc123df4567', 'accessionWF', version: '1')
 ```
 
+Get a JWT token for authentication
+
+```shell
+bundle exec rake generate_token
+```
+
 Hit the technical-metadata-service's HTTP API:
 
 ```shell
-$ curl -i -H 'Content-Type: application/json' --data '{"druid":"druid:bc123df4567","files":["file:///app/README.md","file:///app/openapi.yml"]}' http://localhost:3000/v1/technical-metadata
+$ curl -i H "Authorization: Bearer #{TOKEN}" -H 'Content-Type: application/json' --data '{"druid":"druid:bc123df4567","files":["file:///app/README.md","file:///app/openapi.yml"]}' http://localhost:3000/v1/technical-metadata
 ```
 
 Verify that technical metadata was created:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,31 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::API
+  before_action :check_auth_token
+
+  TOKEN_HEADER = 'Authorization'
+
+  private
+
+  # Ensure a valid token is present, or renders "401: Not Authorized"
+  def check_auth_token
+    token = decoded_auth_token
+    return render json: { error: 'Not Authorized' }, status: :unauthorized unless token
+  end
+
+  def decoded_auth_token
+    @decoded_auth_token ||= begin
+      body = JWT.decode(http_auth_header, Settings.hmac_secret, true, algorithm: 'HS256').first
+      HashWithIndifferentAccess.new body
+                            rescue StandardError
+                              nil
+    end
+  end
+
+  def http_auth_header
+    return if request.headers[TOKEN_HEADER].blank?
+
+    field = request.headers[TOKEN_HEADER]
+    field.split(' ').last
+  end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,2 +1,4 @@
 workflow:
   url: 'https://workflow.example.com/workflow'
+
+hmac_secret: 'my$ecretK3y'

--- a/lib/tasks/jwt.rake
+++ b/lib/tasks/jwt.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+desc 'Generate a JWT token for authentication'
+task generate_token: :environment do
+  print 'Account name: '
+  name = $stdin.gets.chomp
+  payload = { sub: name }
+  puts "Your token:\n#{JWT.encode(payload, Settings.hmac_secret, 'HS256')}"
+end

--- a/spec/requests/create_technical_metadata_spec.rb
+++ b/spec/requests/create_technical_metadata_spec.rb
@@ -1,25 +1,42 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Request create technical metadata' do
+  let(:data) do
+    { druid: 'druid:bc123df4567',
+      files: [
+        'file:///spec/fixtures/test/0001.html',
+        'file:///spec/fixtures/test/bar.txt',
+        'file:///spec/fixtures/test/foo.txt'
+      ] }
+  end
+  let(:payload) { { sub: 'sdr' } }
+  let(:jwt) { JWT.encode(payload, Settings.hmac_secret, 'HS256') }
+
   before do
     allow(TechnicalMetadataJob).to receive(:perform_later)
   end
 
-  it 'queues a job' do
-    post '/v1/technical-metadata',
-         params: {
-           druid: 'druid:bc123df4567',
-           files: [
-             'file:///spec/fixtures/test/0001.html',
-             'file:///spec/fixtures/test/bar.txt',
-             'file:///spec/fixtures/test/foo.txt'
-           ]
-         }.to_json,
-         headers: { 'Content-Type' => 'application/json' }
+  context 'when authorized' do
+    it 'queues a job' do
+      post '/v1/technical-metadata',
+           params: data.to_json,
+           headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
 
-    filepaths = ['/spec/fixtures/test/0001.html', '/spec/fixtures/test/bar.txt', '/spec/fixtures/test/foo.txt']
-    expect(response).to have_http_status(:ok)
-    expect(TechnicalMetadataJob).to have_received(:perform_later).with(druid: 'druid:bc123df4567',
-                                                                       filepaths: filepaths)
+      filepaths = ['/spec/fixtures/test/0001.html', '/spec/fixtures/test/bar.txt', '/spec/fixtures/test/foo.txt']
+      expect(response).to have_http_status(:ok)
+      expect(TechnicalMetadataJob).to have_received(:perform_later).with(druid: 'druid:bc123df4567',
+                                                                         filepaths: filepaths)
+    end
+  end
+
+  context 'when unauthorized' do
+    it 'returns 401' do
+      post '/v1/technical-metadata',
+           params: data.to_json,
+           headers: { 'Content-Type' => 'application/json' }
+
+      expect(response).to be_unauthorized
+      expect(TechnicalMetadataJob).not_to have_received(:perform_later)
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made?

This is a simplified approach from #51 in that it does not include a user model (and thus username/password). This relies on generating a tagged token for each service/user that will hit the service.

## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?

README updated