### PR TITLE
Adds endpoint for getting techmd by druid.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'rails', '~> 6.0.2', '>= 6.0.2.1'
 gem 'committee' # validates Open API spec (OAS)
 gem 'config'
 gem 'honeybadger'
+gem 'jbuilder'
 gem 'jwt'
 gem 'okcomputer'
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,8 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
+    jbuilder (2.10.0)
+      activesupport (>= 5.0.0)
     json (2.3.0)
     json_schema (0.20.8)
     jwt (2.2.1)
@@ -322,6 +324,7 @@ DEPENDENCIES
   dlss-capistrano
   dor-workflow-client (~> 3.17)
   honeybadger
+  jbuilder
   jwt
   listen (>= 3.0.5, < 3.2)
   okcomputer

--- a/app/controllers/technical_metadata_controller.rb
+++ b/app/controllers/technical_metadata_controller.rb
@@ -12,4 +12,10 @@ class TechnicalMetadataController < ApplicationController
 
     head :ok
   end
+
+  # GET /v1/technical-metadata/druid/{druid}
+  def show_by_druid
+    @files = DroFile.where(druid: params[:druid])
+    return head(:not_found) if @files.empty?
+  end
 end

--- a/app/views/technical_metadata/show_by_druid.json.jbuilder
+++ b/app/views/technical_metadata/show_by_druid.json.jbuilder
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+json.ignore_nil!
+json.array! @files, :druid, :filename, :filetype, :mimetype, :bytes, :height, :width

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   scope 'v1' do
     post '/technical-metadata', to: 'technical_metadata#create'
+    get '/technical-metadata/druid/:druid', to: 'technical_metadata#show_by_druid'
   end
 
   mount Sidekiq::Web => '/queues'

--- a/db/migrate/20200221141923_add_druid_index_to_dro_files.rb
+++ b/db/migrate/20200221141923_add_druid_index_to_dro_files.rb
@@ -1,0 +1,5 @@
+class AddDruidIndexToDroFiles < ActiveRecord::Migration[6.0]
+  def change
+    add_index :dro_files, :druid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_20_211359) do
+ActiveRecord::Schema.define(version: 2020_02_21_141923) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2020_02_20_211359) do
     t.integer "height"
     t.integer "width"
     t.index ["druid", "filename"], name: "index_dro_files_on_druid_and_filename", unique: true
+    t.index ["druid"], name: "index_dro_files_on_druid"
   end
 
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -46,6 +46,31 @@ paths:
                   type: array
                   items:
                     $ref: '#/components/schemas/FileURI'
+  /v1/technical-metadata/druid/{druid}:
+    get:
+      tags:
+        - metadata
+      summary: Get the metadata for the files associated with a druid
+      description: ''
+      operationId: technical_metadata#show_by_druid
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TechnicalMetadataResponse'
+        '404':
+          description: Druid not found
+      parameters:
+        - name: druid
+          in: path
+          description: druid for which to return the technical metadata
+          required: true
+          schema:
+            $ref: '#/components/schemas/Druid'
 components:
   schemas:
     Druid:
@@ -58,3 +83,25 @@ components:
       type: string
       pattern: '^file:\/\/\/([^\\/]+\/)*[^\\/]+$'
       example: 'file:///foo/bar/baz/quix.jp2'
+    TechnicalMetadataResponse:
+      description: Technical metadata for a single file
+      type: object
+      properties:
+        druid:
+          $ref: '#/components/schemas/Druid'
+        filename:
+          type: string
+        filetype:
+          description: Pronom id
+          type: string
+        mimetype:
+          type: string
+        bytes:
+          type: integer
+        height:
+          type: integer
+        width:
+          type: integer
+      required:
+        - druid
+        - filename

--- a/spec/requests/show_technical_metadata_spec.rb
+++ b/spec/requests/show_technical_metadata_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Show technical metadata' do
+  let(:payload) { { sub: 'sdr' } }
+  let(:jwt) { JWT.encode(payload, Settings.hmac_secret, 'HS256') }
+
+  before do
+    DroFile.create(druid: 'druid:bc123df4568', filename: '0001.html', md5: '1711cb9f08a0504e1035d198d08edda9',
+                   bytes: 10, filetype: 'test', mimetype: 'text/test', height: 14, width: 15)
+    DroFile.create(druid: 'druid:bc123df4568', filename: '0002.xyz', md5: '2811cb9f08a0504e1035d198d08edda9', bytes: 11)
+  end
+
+  describe 'by druid' do
+    context 'when results' do
+      let(:response_json) do
+        [
+          { 'druid' => 'druid:bc123df4568', 'filename' => '0001.html', 'filetype' => 'test',
+            'mimetype' => 'text/test', 'bytes' => 10, 'height' => 14, 'width' => 15 },
+          { 'druid' => 'druid:bc123df4568', 'filename' => '0002.xyz', 'bytes' => 11 }
+        ]
+      end
+
+      it 'returns the technical metadata' do
+        get '/v1/technical-metadata/druid/druid:bc123df4568',
+            headers: { 'Authorization' => "Bearer #{jwt}", 'Accept' => 'application/json' }
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to eq(response_json)
+      end
+    end
+
+    context 'when no results' do
+      it 'returns 404' do
+        get '/v1/technical-metadata/druid/druid:bc123df4567',
+            headers: { 'Authorization' => "Bearer #{jwt}", 'Accept' => 'application/json' }
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #57

## Why was this change made?
To expose techmd for display in Argo.

## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?
Yes.