### PR TITLE
Handle empty files.

### DIFF
--- a/app/services/technical_metadata_generator.rb
+++ b/app/services/technical_metadata_generator.rb
@@ -65,14 +65,15 @@ class TechnicalMetadataGenerator
   end
 
   def generate_metadata(filepath)
-    filetype, mimetype = file_identifier.identify(filepath: filepath)
-    {
-      filetype: filetype,
-      mimetype: mimetype,
-      tool_versions: {
-        'siegfried' => file_identifier.version
-      }
-    }.deep_merge(generate_metadata_for_mimetype(mimetype, filepath))
+    # Need to provide all keys for upsert, so creating a blank metadata template.
+    metadata = { filetype: nil, mimetype: nil, tool_versions: {} }
+
+    if ::File.size(filepath).positive?
+      metadata[:filetype], metadata[:mimetype] = file_identifier.identify(filepath: filepath)
+      metadata[:tool_versions]['siegfried'] = file_identifier.version
+    end
+
+    metadata.deep_merge(generate_metadata_for_mimetype(metadata[:mimetype], filepath))
   end
 
   def generate_metadata_for_mimetype(mimetype, filepath)

--- a/spec/services/technical_metadata_generator_spec.rb
+++ b/spec/services/technical_metadata_generator_spec.rb
@@ -100,4 +100,22 @@ RSpec.describe TechnicalMetadataGenerator do
       expect(DroFile).not_to exist(filename: '0002.html')
     end
   end
+
+  context 'when some DroFiles are 0 bytes' do
+    let(:filepaths) do
+      [
+        'spec/fixtures/test/0001.html',
+        'spec/fixtures/test/bar.txt',
+        'spec/fixtures/test/foo.jpg',
+        'spec/fixtures/test/zero.txt'
+      ]
+    end
+
+    it 'does not identify them' do
+      expect(errors.length).to eq(0)
+      file = DroFile.find_by!(druid: druid, filename: 'zero.txt')
+      expect(file.bytes).to eq(0)
+      expect(file.filetype).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
closes #62

## Why was this change made?
Don't send empty files to Siegfried, since it logs an error to stdout/stderr, which breaks JSON parsing.


## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?
No.