### PR TITLE
Refactor image metadata

### DIFF
--- a/app/services/image_characterizer_service.rb
+++ b/app/services/image_characterizer_service.rb
@@ -8,7 +8,7 @@ class ImageCharacterizerService
   end
 
   # @param [String] filepath of the image to characterize
-  # @return [Integer,Integer|nil,nil] height, width of the image or nil, nil if unknown
+  # @return [Hash] attributes including height and width
   # @raise [ImageCharacterizerService::Error]
   def characterize(filepath:)
     output, status = Open3.capture2e("exiftool -ImageHeight -ImageWidth -json #{filepath}")
@@ -38,7 +38,11 @@ class ImageCharacterizerService
     json_output.each do |file|
       next unless file['SourceFile'] == filepath
 
-      return file['ImageHeight'], file['ImageWidth']
+      attributes = {}.tap do |metadata|
+        metadata[:height] = file['ImageHeight'] unless file['ImageHeight'].nil?
+        metadata[:width] = file['ImageWidth'] unless file['ImageWidth'].nil?
+      end
+      return attributes.presence
     end
 
     raise Error, "Unable to find image attributes for #{filepath} in: #{output}"

--- a/app/services/technical_metadata_generator.rb
+++ b/app/services/technical_metadata_generator.rb
@@ -79,12 +79,12 @@ class TechnicalMetadataGenerator
   def generate_metadata_for_mimetype(mimetype, filepath)
     # Additional characterizers can be added here.
     # Need to provide all keys for upsert, so creating a blank metadata template.
-    metadata = { height: nil, width: nil, pdf_metadata: nil }
+    metadata = { image_metadata: nil, pdf_metadata: nil }
 
     return metadata if mimetype.nil?
 
     if mimetype.start_with?('image/')
-      metadata[:height], metadata[:width] = image_characterizer.characterize(filepath: filepath)
+      metadata[:image_metadata] = image_characterizer.characterize(filepath: filepath)
       metadata[:tool_versions] = { 'exiftool' => image_characterizer.version }
     elsif mimetype == 'application/pdf'
       metadata[:pdf_metadata] = pdf_characterizer.characterize(filepath: filepath)

--- a/app/views/technical_metadata/show_by_druid.json.jbuilder
+++ b/app/views/technical_metadata/show_by_druid.json.jbuilder
@@ -2,4 +2,4 @@
 
 json.ignore_nil!
 json.array! @files, :druid, :filename, :filetype, :mimetype, :bytes, :file_create, :file_modification,
-            :height, :width, :pdf_metadata
+            :image_metadata, :pdf_metadata

--- a/db/migrate/20200226043038_add_image_metadata_to_dro_files.rb
+++ b/db/migrate/20200226043038_add_image_metadata_to_dro_files.rb
@@ -1,0 +1,7 @@
+class AddImageMetadataToDroFiles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :dro_files, :image_metadata, :jsonb
+    remove_column :dro_files, :height, :integer
+    remove_column :dro_files, :width, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,11 +25,10 @@ ActiveRecord::Schema.define(version: 2020_02_26_055313) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "mimetype"
-    t.integer "height"
-    t.integer "width"
     t.datetime "file_modification"
     t.datetime "file_create"
     t.jsonb "pdf_metadata"
+    t.jsonb "image_metadata"
     t.index ["druid", "filename"], name: "index_dro_files_on_druid_and_filename", unique: true
     t.index ["druid"], name: "index_dro_files_on_druid"
   end

--- a/openapi.yml
+++ b/openapi.yml
@@ -83,6 +83,14 @@ components:
       type: string
       pattern: '^file:\/\/\/([^\\/]+\/)*[^\\/]+$'
       example: 'file:///foo/bar/baz/quix.jp2'
+    ImageMetadata:
+      description: Image-specific technical metadata
+      type: object
+      properties:
+        height:
+          type: integer
+        width:
+          type: integer
     PdfMetadata:
       description: PDF-specific technical metadata
       type: object
@@ -128,10 +136,8 @@ components:
         file_modification:
           type: string
           format: date-time
-        height:
-          type: integer
-        width:
-          type: integer
+        image_metadata:
+          $ref: '#/components/schemas/ImageMetadata'
         pdf_metdata:
           $ref: '#/components/schemas/PdfMetadata'
       required:

--- a/spec/requests/show_technical_metadata_spec.rb
+++ b/spec/requests/show_technical_metadata_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Show technical metadata' do
 
   before do
     DroFile.create(druid: 'druid:bc123df4568', filename: '0001.html', md5: '1711cb9f08a0504e1035d198d08edda9',
-                   bytes: 10, filetype: 'test', mimetype: 'text/test', height: 14, width: 15)
+                   bytes: 10, filetype: 'test', mimetype: 'text/test', image_metadata: { height: 14, width: 15 })
     DroFile.create(druid: 'druid:bc123df4568', filename: '0002.xyz', md5: '2811cb9f08a0504e1035d198d08edda9', bytes: 11)
   end
 
@@ -15,7 +15,7 @@ RSpec.describe 'Show technical metadata' do
       let(:response_json) do
         [
           { 'druid' => 'druid:bc123df4568', 'filename' => '0001.html', 'filetype' => 'test',
-            'mimetype' => 'text/test', 'bytes' => 10, 'height' => 14, 'width' => 15 },
+            'mimetype' => 'text/test', 'bytes' => 10, 'image_metadata' => { 'height' => 14, 'width' => 15 } },
           { 'druid' => 'druid:bc123df4568', 'filename' => '0002.xyz', 'bytes' => 11 }
         ]
       end

--- a/spec/services/image_characterizer_service_spec.rb
+++ b/spec/services/image_characterizer_service_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe ImageCharacterizerService do
       let(:status) { instance_double(Process::Status, success?: true) }
 
       it 'returns height and width' do
-        expect(characterization).to eq([694, 1366])
+        expect(characterization).to eq(height: 694, width: 1366)
         expect(Open3).to have_received(:capture2e).with('exiftool -ImageHeight -ImageWidth -json bar.png')
       end
     end
@@ -79,7 +79,7 @@ RSpec.describe ImageCharacterizerService do
       let(:status) { instance_double(Process::Status, success?: true) }
 
       it 'returns nil' do
-        expect(characterization).to eq([nil, nil])
+        expect(characterization).to eq(nil)
       end
     end
 

--- a/spec/services/technical_metadata_generator_spec.rb
+++ b/spec/services/technical_metadata_generator_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe TechnicalMetadataGenerator do
                                                         .and_return(['fmt/20', 'application/pdf'])
     allow(ImageCharacterizerService).to receive(:new).and_return(image_characterizer_service)
     allow(image_characterizer_service).to receive(:characterize).with(filepath: 'spec/fixtures/test/foo.jpg')
-                                                                .and_return([200, 151])
+                                                                .and_return(height: 200, width: 151)
     allow(PdfCharacterizerService).to receive(:new).and_return(pdf_characterizer_service)
     allow(pdf_characterizer_service).to receive(:characterize).with(filepath: 'spec/fixtures/test/brief.pdf').and_return(form: false,
                                                                                                                          pages: 111,
@@ -75,8 +75,8 @@ RSpec.describe TechnicalMetadataGenerator do
         expect(file3.filetype).to eq('fmt/43')
         expect(file3.mimetype).to eq('image/jpeg')
         expect(file3.bytes).to eq(16_245)
-        expect(file3.height).to eq(200)
-        expect(file3.width).to eq(151)
+        expect(file3.image_metadata['height']).to eq(200)
+        expect(file3.image_metadata['width']).to eq(151)
         expect(file3.tool_versions).to eq('siegfried' => '1.4.5', 'exiftool' => '11.85')
 
         file4 = DroFile.find_by!(druid: druid, filename: 'brief.pdf')


### PR DESCRIPTION
## Why was this change made?
To make the model consistent with PDF metadata (viz., image-specific metadata stored in a JSONB field).


## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?
Yes


## Does this change affect how this application integrates with other services?
No

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
