### PR TITLE
Filenames with spaces

### DIFF
--- a/app/services/av_characterizer_service.rb
+++ b/app/services/av_characterizer_service.rb
@@ -11,7 +11,7 @@ class AvCharacterizerService
   # @return [Hash, Array<Hash>] attributes, array of file part attributes.
   # @raise [AvCharacterizerService::Error]
   def characterize(filepath:)
-    output, status = Open3.capture2e("mediainfo -f --Output=JSON #{filepath}")
+    output, status = Open3.capture2e('mediainfo', '-f', '--Output=JSON', filepath)
     raise Error, "Characterizing #{filepath} returned #{status.exitstatus}: #{output}" unless status.success?
 
     extract(output, filepath)

--- a/app/services/file_identifier_service.rb
+++ b/app/services/file_identifier_service.rb
@@ -11,7 +11,7 @@ class FileIdentifierService
   # @return [String,String|nil,nil] pronom id, mimetype of the file or nil, nil if unknown
   # @raise [FileIdentifierService::Error]
   def identify(filepath:)
-    output, status = Open3.capture2e("sf -json #{filepath}")
+    output, status = Open3.capture2e('sf', '-json', filepath)
     raise Error, "Identifying #{filepath} returned #{status.exitstatus}: #{output}" unless status.success?
 
     extract_file_types(output, filepath)

--- a/app/services/image_characterizer_service.rb
+++ b/app/services/image_characterizer_service.rb
@@ -11,7 +11,7 @@ class ImageCharacterizerService
   # @return [Hash] attributes including height and width
   # @raise [ImageCharacterizerService::Error]
   def characterize(filepath:)
-    output, status = Open3.capture2e("exiftool -ImageHeight -ImageWidth -json #{filepath}")
+    output, status = Open3.capture2e('exiftool', '-ImageHeight', '-ImageWidth', '-json', filepath)
     raise Error, "Characterizing #{filepath} returned #{status.exitstatus}: #{output}" unless status.success?
 
     extract_attributes(output, filepath)

--- a/app/services/pdf_characterizer_service.rb
+++ b/app/services/pdf_characterizer_service.rb
@@ -12,7 +12,7 @@ class PdfCharacterizerService
   #   form, creator, producer
   # @raise [PdfCharacterizerService::Error]
   def characterize(filepath:)
-    output, status = Open3.capture2e("pdfinfo #{filepath}")
+    output, status = Open3.capture2e('pdfinfo', filepath)
     raise Error, "Characterizing #{filepath} returned #{status.exitstatus}: #{output}" unless status.success?
 
     extract_attributes(output).merge(text: text?(filepath))

--- a/spec/services/av_characterizer_service_spec.rb
+++ b/spec/services/av_characterizer_service_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe AvCharacterizerService do
                                            audio_metadata: { channels: '1', sampling_rate: 44_100,
                                                              stream_size: 10_020 },
                                            video_metadata: nil, other_metadata: nil }]])
-        expect(Open3).to have_received(:capture2e).with('mediainfo -f --Output=JSON noam.ogg')
+        expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', 'noam.ogg')
       end
     end
 
@@ -197,7 +197,7 @@ RSpec.describe AvCharacterizerService do
                                            audio_metadata: { codec_id: 'A_OPUS', channels: '2', sampling_rate: 48_000,
                                                              bit_depth: 32 },
                                            video_metadata: nil, other_metadata: nil }]])
-        expect(Open3).to have_received(:capture2e).with('mediainfo -f --Output=JSON max.webm')
+        expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', 'max.webm')
       end
     end
 
@@ -235,7 +235,7 @@ RSpec.describe AvCharacterizerService do
                                         [{ part_type: 'text', part_id: '2', order: 1, format: nil,
                                            audio_metadata: nil,
                                            video_metadata: nil, other_metadata: nil }]])
-        expect(Open3).to have_received(:capture2e).with('mediainfo -f --Output=JSON make_believe.xyz')
+        expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', 'make_believe.xyz')
       end
     end
 
@@ -277,7 +277,7 @@ RSpec.describe AvCharacterizerService do
                                            audio_metadata: nil,
                                            video_metadata: nil,
                                            other_metadata: { title: title } }]])
-        expect(Open3).to have_received(:capture2e).with('mediainfo -f --Output=JSON make_believe.xyz')
+        expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', 'make_believe.xyz')
       end
     end
 

--- a/spec/services/file_identifier_service_spec.rb
+++ b/spec/services/file_identifier_service_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe FileIdentifierService do
 
       it 'returns pronom id and mimetype' do
         expect(identifiers).to eq(['x-fmt/111', 'text/plain'])
-        expect(Open3).to have_received(:capture2e).with('sf -json bar.txt')
+        expect(Open3).to have_received(:capture2e).with('sf', '-json', 'bar.txt')
       end
     end
 

--- a/spec/services/image_characterizer_service_spec.rb
+++ b/spec/services/image_characterizer_service_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe ImageCharacterizerService do
 
       it 'returns height and width' do
         expect(characterization).to eq(height: 694, width: 1366)
-        expect(Open3).to have_received(:capture2e).with('exiftool -ImageHeight -ImageWidth -json bar.png')
+        expect(Open3).to have_received(:capture2e).with('exiftool', '-ImageHeight', '-ImageWidth', '-json', 'bar.png')
       end
     end
 

--- a/spec/services/pdf_characterizer_service_spec.rb
+++ b/spec/services/pdf_characterizer_service_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe PdfCharacterizerService do
                                        page_size: '612 x 792 pts (letter)',
                                        pdf_version: '1.6',
                                        text: true)
-        expect(Open3).to have_received(:capture2e).with('pdfinfo brief.pdf')
+        expect(Open3).to have_received(:capture2e).with('pdfinfo', 'brief.pdf')
       end
     end
 


### PR DESCRIPTION
## Why was this change made?
To support filenames that have spaces by using array format for cmd rather than string.


## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?
No.


## Does this change affect how this application integrates with other services?
No.

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
