### PR TITLE
Fix to Dockerfile

### DIFF
--- a/docker/workers/Dockerfile
+++ b/docker/workers/Dockerfile
@@ -10,7 +10,7 @@ FROM ruby:2.7.0-buster
 RUN curl -sS https://bintray.com/user/downloadSubjectPublicKey?username=bintray | apt-key add - && \
   echo "deb http://dl.bintray.com/siegfried/debian wheezy main" | tee -a /etc/apt/sources.list && \
   apt-get update -qq && \
-  apt-get install -y build-essential postgresql-client siegfried exiftool popper-utils mediainfo
+  apt-get install -y build-essential postgresql-client siegfried exiftool poppler-utils mediainfo
 
 # Get bundler 2.0
 RUN gem install bundler


### PR DESCRIPTION
## Why was this change made?
Dockerfile was trying to install an invalid package.


## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?



## Does this change affect how this application integrates with other services?

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
