### PR TITLE
Adds support for parsing results from old and new siegfried.

### DIFF
--- a/app/services/file_identifier_service.rb
+++ b/app/services/file_identifier_service.rb
@@ -39,8 +39,8 @@ class FileIdentifierService
       next unless file['filename'] == filepath
 
       file['matches'].each do |match|
-        # Depending on the version of siegfried, either ns or id field.
-        next unless match['ns'] == 'pronom' || match['id'] == 'pronom'
+        # Note that the structure of matches depends on the version of siegfried. Old and new siegfried are handled.
+        next unless pronom_match?(match)
 
         return [extract_pronom_id(match), extract_mimetype(match)]
       end
@@ -50,12 +50,17 @@ class FileIdentifierService
   end
 
   def extract_pronom_id(match)
-    return nil if match['id'] == 'UNKNOWN'
+    id = match['ns'] == 'pronom' ? match['id'] : match['puid']
+    return nil if id == 'UNKNOWN'
 
-    match['id'].presence
+    id.presence
   end
 
   def extract_mimetype(match)
     match['mime'].presence
+  end
+
+  def pronom_match?(match)
+    match['ns'] == 'pronom' || match['id'] == 'pronom'
   end
 end

--- a/spec/services/file_identifier_service_spec.rb
+++ b/spec/services/file_identifier_service_spec.rb
@@ -49,21 +49,33 @@ RSpec.describe FileIdentifierService do
   end
 
   describe '#identify' do
-    let(:identifiers) { service.identify(filepath: 'bar.txt') }
+    let(:identifiers) { service.identify(filepath: '0001.html') }
 
-    context 'when file is identified' do
-      let(:output) { '{"siegfried":"1.8.0","scandate":"2020-02-18T16:44:36-05:00","signature":"default.sig","created":"2020-01-21T23:30:42+01:00","identifiers":[{"name":"pronom","details":"DROID_SignatureFile_V96.xml; container-signature-20200121.xml"}],"files":[{"filename":"bar.txt","filesize": 4,"modified":"2020-02-18T15:36:15-05:00","errors": "","matches": [{"ns":"pronom","id":"x-fmt/111","format":"Plain Text File","version":"","mime":"text/plain","basis":"extension match txt; text match ASCII","warning":""}]}]}' }
+    context 'when file is identified with old siegfried' do
+      let(:output) { '{"siegfried":"1.4.5","scandate":"2020-03-03T12:28:39-05:00","signature":"pronom.sig","created":"2016-02-05T17:41:10+11:00","identifiers":[{"name":"pronom","details":"DROID_SignatureFile_V84.xml; container-signature-20160121.xml"}],"files":[{"filename":"0001.html","filesize": 38,"modified":"2020-02-19T09:11:41-05:00","errors": "","matches": [{"id":"pronom","puid":"fmt/96","format":"Hypertext Markup Language","version":"","mime":"text/html","basis":"extension match; byte match at [[[0 5]] [[31 7]]] (signature 1/2)","warning":""}]}]}' }
 
       let(:status) { instance_double(Process::Status, success?: true) }
 
       it 'returns pronom id and mimetype' do
-        expect(identifiers).to eq(['x-fmt/111', 'text/plain'])
-        expect(Open3).to have_received(:capture2e).with('sf', '-json', 'bar.txt')
+        expect(identifiers).to eq(['fmt/96', 'text/html'])
+        expect(Open3).to have_received(:capture2e).with('sf', '-json', '0001.html')
+      end
+    end
+
+    # Siegfried returns different formats depending on the version. This tests the other format.
+    context 'when file is identified with new siegfried' do
+      let(:output) { '{"siegfried":"1.8.0","scandate":"2020-03-03T09:30:57-08:00","signature":"default.sig","created":"2020-01-21T23:30:42+01:00","identifiers":[{"name":"pronom","details":"DROID_SignatureFile_V96.xml; container-signature-20200121.xml"}],"files":[{"filename":"0001.html","filesize": 38,"modified":"2020-03-02T14:45:13-08:00","errors": "","matches": [{"ns":"pronom","id":"fmt/96","format":"Hypertext Markup Language","version":"","mime":"text/html","basis":"extension match html; byte match at [[0 5] [31 7]] (signature 1/2)","warning":""}]}]}' }
+
+      let(:status) { instance_double(Process::Status, success?: true) }
+
+      it 'returns pronom id and mimetype' do
+        expect(identifiers).to eq(['fmt/96', 'text/html'])
+        expect(Open3).to have_received(:capture2e).with('sf', '-json', '0001.html')
       end
     end
 
     context 'when file is not identified' do
-      let(:output) { '{"siegfried":"1.8.0","scandate":"2020-02-18T16:44:36-05:00","signature":"default.sig","created":"2020-01-21T23:30:42+01:00","identifiers":[{"name":"pronom","details":"DROID_SignatureFile_V96.xml; container-signature-20200121.xml"}],"files":[{"filename":"bar.txt","filesize": 933521532,"modified":"2020-02-18T12:25:17-05:00","errors": "","matches": [{"ns":"pronom","id":"UNKNOWN","format":"","version":"","mime":"","basis":"","warning":"no match"}]}]}' }
+      let(:output) { '{"siegfried":"1.8.0","scandate":"2020-02-18T16:44:36-05:00","signature":"default.sig","created":"2020-01-21T23:30:42+01:00","identifiers":[{"name":"pronom","details":"DROID_SignatureFile_V96.xml; container-signature-20200121.xml"}],"files":[{"filename":"0001.html","filesize": 933521532,"modified":"2020-02-18T12:25:17-05:00","errors": "","matches": [{"ns":"pronom","id":"UNKNOWN","format":"","version":"","mime":"","basis":"","warning":"no match"}]}]}' }
 
       let(:status) { instance_double(Process::Status, success?: true) }
 


### PR DESCRIPTION
## Why was this change made?
Different versions of siegfried produce results in slightly different formats. We have old and new siegfried deployed locally, in docker images, and in stage/production. This handles all.


## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?
No.


## Does this change affect how this application integrates with other services?
No.
If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
