### PR TITLE
rename rake task and tweak descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,25 +121,23 @@ $ rails c
 ```
 
 ## Rake
-To generate for an item:
+To generate for an item, synchronously and not updating workflow service:
 
 ```shell
 $ bundler exec rake techmd:generate['druid:bc123df4567','spec/fixtures/test/0001.html spec/fixtures/test/bar.txt spec/fixtures/test/brief.pdf spec/fixtures/test/foo.jpg spec/fixtures/test/max.webm spec/fixtures/test/noam.ogg']
 Success
 ```
 
-To generate for an item from a moab (preservation storage):
+To generate for an item from a Moab (from preservation storage):
 
 ```shell
-$ bundler exec rake techmd:generate_moab['druid:bc123df4567']
+$ bundler exec rake techmd:generate_for_moab['druid:bc123df4567']
 Queued
 ```
 
 ## Docker
 
-
 Note that this project's continuous integration build will automatically create and publish an updated image whenever there is a passing build from the `master` branch. If you do need to manually create and publish an image, do the following:
-
 
 Build image:
 

--- a/lib/tasks/technical_metadata.rake
+++ b/lib/tasks/technical_metadata.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 namespace :techmd do
-  desc 'Generate technical metadata'
+  desc 'Generate technical metadata (synchronously) from druid + filepaths'
   task :generate, %i[druid filepaths] => :environment do |_task, args|
     errors = TechnicalMetadataGenerator.generate(druid: args[:druid], filepaths: args[:filepaths].split(' '))
     if errors.empty?
@@ -11,8 +11,8 @@ namespace :techmd do
     end
   end
 
-  desc 'Generate technical metadata from moab'
-  task :generate_moab, %i[druid] => :environment do |_task, args|
+  desc 'Generate technical metadata from Moab'
+  task :generate_for_moab, %i[druid] => :environment do |_task, args|
     MoabProcessingService.process(druid: args[:druid])
     puts 'Queued'
   end


### PR DESCRIPTION
## Why was this change made?

`generate_moab` isn't the best name for a rake task that generates technical metadata.

fixes #94

## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?

README - yup.
description of rake tasks - yup.

## Does this change affect how this application integrates with other services?

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
