### PR TITLE
Fix video standard attribute

### DIFF
--- a/app/services/av_characterizer_service.rb
+++ b/app/services/av_characterizer_service.rb
@@ -100,7 +100,7 @@ class AvCharacterizerService
       metadata[:bit_depth] = track['BitDepth'].to_i if track['BitDepth'].present?
       metadata[:language] = track['Language'] if track['Language'].present?
       metadata[:stream_size] = track['StreamSize'].to_i if track['StreamSize'].present?
-      metadata[:standard] = track['Standard'].to_i if track['Standard'].present?
+      metadata[:standard] = track['Standard'] if track['Standard'].present?
     end
     part
   end

--- a/spec/services/av_characterizer_service_spec.rb
+++ b/spec/services/av_characterizer_service_spec.rb
@@ -152,7 +152,8 @@ RSpec.describe AvCharacterizerService do
           "FrameCount": "995",
           "Encoded_Library": "Lavc58.35.100 libvpx-vp9",
           "Default": "Yes",
-          "Forced": "No"
+          "Forced": "No",
+          "Standard": "NTSC"
           },
           {
           "@type": "Audio",
@@ -191,7 +192,7 @@ RSpec.describe AvCharacterizerService do
                                            audio_metadata: nil,
                                            video_metadata: { codec_id: 'V_VP9', height: 480, width: 640,
                                                              display_aspect_ratio: 1.333, pixel_aspect_ratio: 1.0,
-                                                             frame_rate: 29.97 },
+                                                             frame_rate: 29.97, standard: 'NTSC' },
                                            other_metadata: nil },
                                          { part_type: 'audio', part_id: '2', order: 1, format: 'Opus',
                                            audio_metadata: { codec_id: 'A_OPUS', channels: '2', sampling_rate: 48_000,


### PR DESCRIPTION
## Why was this change made?
The standard attribute of a video should be a string, not a float.


## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?
No.


## Does this change affect how this application integrates with other services?
No.

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
