### PR TITLE
Adds support for forcing generating techmd.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,14 +124,14 @@ $ rails c
 To generate for an item, synchronously and not updating workflow service:
 
 ```shell
-$ bundler exec rake techmd:generate['druid:bc123df4567','spec/fixtures/test/0001.html spec/fixtures/test/bar.txt spec/fixtures/test/brief.pdf spec/fixtures/test/foo.jpg spec/fixtures/test/max.webm spec/fixtures/test/noam.ogg']
+$ bundler exec rake techmd:generate['druid:bc123df4567','spec/fixtures/test/0001.html spec/fixtures/test/bar.txt spec/fixtures/test/brief.pdf spec/fixtures/test/foo.jpg spec/fixtures/test/max.webm spec/fixtures/test/noam.ogg', 'true']
 Success
 ```
 
 To generate for an item from a Moab (from preservation storage):
 
 ```shell
-$ bundler exec rake techmd:generate_for_moab['druid:bc123df4567']
+$ bundler exec rake techmd:generate_for_moab['druid:bc123df4567', 'true']
 Queued
 ```
 

--- a/app/controllers/technical_metadata_controller.rb
+++ b/app/controllers/technical_metadata_controller.rb
@@ -8,7 +8,7 @@ class TechnicalMetadataController < ApplicationController
   def create
     druid, file_uris = params.require(%i[druid files])
     filepaths = file_uris.map { |file_uri| URI(file_uri).path }
-    TechnicalMetadataWorkflowJob.perform_later(druid: druid, filepaths: filepaths)
+    TechnicalMetadataWorkflowJob.perform_later(druid: druid, filepaths: filepaths, force: params[:force] == true)
 
     head :ok
   end

--- a/app/jobs/technical_metadata_job.rb
+++ b/app/jobs/technical_metadata_job.rb
@@ -6,8 +6,9 @@ class TechnicalMetadataJob < ApplicationJob
 
   # @param [String] druid
   # @param [Array<String>] filepaths of files
-  def perform(druid:, filepaths:)
-    errors = TechnicalMetadataGenerator.generate(druid: druid, filepaths: filepaths)
+  # @param [Boolean] force even if md5 match
+  def perform(druid:, filepaths:, force: false)
+    errors = TechnicalMetadataGenerator.generate(druid: druid, filepaths: filepaths, force: force)
 
     Honeybadger.notify("Generating technical metadata for #{druid} failed: #{errors}") unless errors.empty?
   end

--- a/app/services/moab_processing_service.rb
+++ b/app/services/moab_processing_service.rb
@@ -2,22 +2,24 @@
 
 # Queues metadata generation for files stored as moabs.
 class MoabProcessingService
-  def self.process(druid:)
-    new(druid: druid).process
+  def self.process(druid:, force: false)
+    new(druid: druid, force: force).process
   end
 
   # @param [String] druid
-  def initialize(druid:)
+  # @param [Boolean] force even if md5 match
+  def initialize(druid:, force: false)
     @druid = druid
+    @force = force
   end
 
   def process
-    TechnicalMetadataJob.perform_later(druid: druid, filepaths: filepaths)
+    TechnicalMetadataJob.perform_later(druid: druid, filepaths: filepaths, force: force)
   end
 
   private
 
-  attr_reader :druid
+  attr_reader :druid, :force
 
   def filepaths
     storage_object = Moab::StorageServices.find_storage_object(druid)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,9 +43,6 @@ ActiveRecord::Schema.define(version: 2020_03_04_012620) do
     t.jsonb "av_metadata"
     t.index ["druid", "filename"], name: "index_dro_files_on_druid_and_filename", unique: true
     t.index ["druid"], name: "index_dro_files_on_druid"
-    t.index ["filetype"], name: "index_dro_files_on_filetype"
-    t.index ["mimetype"], name: "index_dro_files_on_mimetype"
-    t.index ["updated_at"], name: "index_dro_files_on_updated_at"
   end
 
   add_foreign_key "dro_file_parts", "dro_files"

--- a/lib/tasks/technical_metadata.rake
+++ b/lib/tasks/technical_metadata.rake
@@ -2,8 +2,10 @@
 
 namespace :techmd do
   desc 'Generate technical metadata (synchronously) from druid + filepaths'
-  task :generate, %i[druid filepaths] => :environment do |_task, args|
-    errors = TechnicalMetadataGenerator.generate(druid: args[:druid], filepaths: args[:filepaths].split(' '))
+  task :generate, %i[druid filepaths force] => :environment do |_task, args|
+    errors = TechnicalMetadataGenerator.generate(druid: args[:druid],
+                                                 filepaths: args[:filepaths].split(' '),
+                                                 force: args[:force] == 'true')
     if errors.empty?
       puts 'Success'
     else
@@ -12,8 +14,8 @@ namespace :techmd do
   end
 
   desc 'Generate technical metadata from Moab'
-  task :generate_for_moab, %i[druid] => :environment do |_task, args|
-    MoabProcessingService.process(druid: args[:druid])
+  task :generate_for_moab, %i[druid force] => :environment do |_task, args|
+    MoabProcessingService.process(druid: args[:druid], force: args[:force] == 'true')
     puts 'Queued'
   end
 end

--- a/openapi.yml
+++ b/openapi.yml
@@ -46,6 +46,8 @@ paths:
                   type: array
                   items:
                     $ref: '#/components/schemas/FileURI'
+                force:
+                  type: boolean
   /v1/technical-metadata/druid/{druid}:
     get:
       tags:

--- a/spec/jobs/technical_metadata_job_spec.rb
+++ b/spec/jobs/technical_metadata_job_spec.rb
@@ -16,14 +16,16 @@ RSpec.describe TechnicalMetadataJob do
   before do
     allow(TechnicalMetadataGenerator).to receive(:generate).and_return(errors)
     allow(Honeybadger).to receive(:notify)
-    job.perform(druid: druid, filepaths: filepaths)
+    job.perform(druid: druid, filepaths: filepaths, force: true)
   end
 
   context 'when no errors' do
     let(:errors) { [] }
 
     it('does nothing') do
-      expect(TechnicalMetadataGenerator).to have_received(:generate).with(druid: druid, filepaths: filepaths)
+      expect(TechnicalMetadataGenerator).to have_received(:generate).with(druid: druid,
+                                                                          filepaths: filepaths,
+                                                                          force: true)
     end
   end
 

--- a/spec/requests/create_technical_metadata_spec.rb
+++ b/spec/requests/create_technical_metadata_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe 'Request create technical metadata' do
         'file:///spec/fixtures/test/0001.html',
         'file:///spec/fixtures/test/bar.txt',
         'file:///spec/fixtures/test/foo.txt'
-      ] }
+      ],
+      force: true }
   end
   let(:payload) { { sub: 'sdr' } }
   let(:jwt) { JWT.encode(payload, Settings.hmac_secret, 'HS256') }
@@ -25,7 +26,7 @@ RSpec.describe 'Request create technical metadata' do
       filepaths = ['/spec/fixtures/test/0001.html', '/spec/fixtures/test/bar.txt', '/spec/fixtures/test/foo.txt']
       expect(response).to have_http_status(:ok)
       expect(TechnicalMetadataWorkflowJob).to have_received(:perform_later).with(druid: 'druid:bc123df4567',
-                                                                                 filepaths: filepaths)
+                                                                                 filepaths: filepaths, force: true)
     end
   end
 

--- a/spec/services/moab_processing_service_spec.rb
+++ b/spec/services/moab_processing_service_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe MoabProcessingService do
-  let(:service) { described_class.new(druid: druid) }
+  let(:service) { described_class.new(druid: druid, force: true) }
 
   let(:druid) { 'druid:bj102hs9687' }
 
@@ -15,7 +15,8 @@ RSpec.describe MoabProcessingService do
       expect(TechnicalMetadataJob).to have_received(:perform_later)
         .with(druid: druid,
               filepaths: ['spec/fixtures/storage_root01/sdr2objects/bj/102/hs/9687/bj102hs9687/v0001/data/content/eric-smith-dissertation.pdf',
-                          'spec/fixtures/storage_root01/sdr2objects/bj/102/hs/9687/bj102hs9687/v0001/data/content/eric-smith-dissertation-augmented.pdf'])
+                          'spec/fixtures/storage_root01/sdr2objects/bj/102/hs/9687/bj102hs9687/v0001/data/content/eric-smith-dissertation-augmented.pdf'],
+              force: true)
     end
   end
 end


### PR DESCRIPTION
closes #101

## Why was this change made?
To allow forcing generating techmd even when MD5 match. Will want to do this when a tool or techmd schema changes.


## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?
Yes.


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
No.
