### PR TITLE
Add missed force param to technical_metadata_workflow_job.

### DIFF
--- a/app/jobs/technical_metadata_workflow_job.rb
+++ b/app/jobs/technical_metadata_workflow_job.rb
@@ -8,9 +8,9 @@ class TechnicalMetadataWorkflowJob < ApplicationJob
 
   # @param [String] druid
   # @param [Array<String>] filepaths of files
-  def perform(druid:, filepaths:)
+  def perform(druid:, filepaths:, force: false)
     start = Time.zone.now
-    errors = TechnicalMetadataGenerator.generate(druid: druid, filepaths: filepaths)
+    errors = TechnicalMetadataGenerator.generate(druid: druid, filepaths: filepaths, force: force)
     if errors.empty?
       log_success(druid: druid, elapsed: Time.zone.now - start)
     else


### PR DESCRIPTION
closes #105

## Why was this change made?
Fix a bug for a missing param.


## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?
No


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
No