### PR TITLE
Unescape URLs

### DIFF
--- a/app/controllers/technical_metadata_controller.rb
+++ b/app/controllers/technical_metadata_controller.rb
@@ -7,7 +7,7 @@ class TechnicalMetadataController < ApiController
   # POST /v1/technical-metadata
   def create
     druid, file_uris = params.require(%i[druid files])
-    filepaths = file_uris.map { |file_uri| URI(file_uri).path }
+    filepaths = file_uris.map { |file_uri| CGI.unescape(URI(file_uri).path) }
     TechnicalMetadataWorkflowJob.perform_later(druid: druid, filepaths: filepaths, force: params[:force] == true)
 
     head :ok

--- a/spec/requests/create_technical_metadata_spec.rb
+++ b/spec/requests/create_technical_metadata_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe 'Request create technical metadata' do
       files: [
         'file:///spec/fixtures/test/0001.html',
         'file:///spec/fixtures/test/bar.txt',
-        'file:///spec/fixtures/test/foo.txt'
+        'file:///spec/fixtures/test/foo.txt',
+        'file:///spec/fixtures/test/one%20space.txt'
       ],
       force: true }
   end
@@ -18,12 +19,18 @@ RSpec.describe 'Request create technical metadata' do
   end
 
   context 'when authorized' do
+    let(:filepaths) do
+      ['/spec/fixtures/test/0001.html',
+       '/spec/fixtures/test/bar.txt',
+       '/spec/fixtures/test/foo.txt',
+       '/spec/fixtures/test/one space.txt']
+    end
+
     it 'queues a job' do
       post '/v1/technical-metadata',
            params: data.to_json,
            headers: { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" }
 
-      filepaths = ['/spec/fixtures/test/0001.html', '/spec/fixtures/test/bar.txt', '/spec/fixtures/test/foo.txt']
       expect(response).to have_http_status(:ok)
       expect(TechnicalMetadataWorkflowJob).to have_received(:perform_later).with(druid: 'druid:bc123df4567',
                                                                                  filepaths: filepaths, force: true)


### PR DESCRIPTION
## Why was this change made?

Previously urls were not unescaping spaces (`%20`) and then they couldn't find the file.


## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?

n/a

## Does this change affect how this application integrates with other services

no
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
