### PR TITLE
Changes invocation of pdftotext.

### DIFF
--- a/app/services/pdf_characterizer_service.rb
+++ b/app/services/pdf_characterizer_service.rb
@@ -35,7 +35,7 @@ class PdfCharacterizerService
   private
 
   def text?(filepath)
-    output, status = Open3.capture2e("pdftotext #{filepath} -")
+    output, status = Open3.capture2e('pdftotext', filepath, '-')
     raise Error, "Extracting text from #{filepath} returned #{status.exitstatus}: #{output}" unless status.success?
 
     output.present?

--- a/spec/services/pdf_characterizer_service_spec.rb
+++ b/spec/services/pdf_characterizer_service_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe PdfCharacterizerService do
                                        pdf_version: '1.6',
                                        text: true)
         expect(Open3).to have_received(:capture2e).with('pdfinfo', 'brief.pdf')
+        expect(Open3).to have_received(:capture2e).with('pdftotext', 'brief.pdf', '-')
       end
     end
 


### PR DESCRIPTION
closes #124

## Why was this change made?
So that pdf text extraction could handle filenames with spaces.


## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?
No.


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
Tested on prod.