### PR TITLE
Switched to using capture3 for siegfried.

### DIFF
--- a/spec/services/file_identifier_service_spec.rb
+++ b/spec/services/file_identifier_service_spec.rb
@@ -4,13 +4,18 @@ require 'open3'
 
 RSpec.describe FileIdentifierService do
   let(:service) { described_class.new }
+  let(:err) { '' }
 
   before do
-    allow(Open3).to receive(:capture2e).and_return([output, status])
+    allow(Open3).to receive(:capture3).and_return([output, err, status])
   end
 
   describe '#version' do
     let(:version) { service.version }
+
+    before do
+      allow(Open3).to receive(:capture2e).and_return([output, status])
+    end
 
     context 'when siegfried returns version' do
       let(:output) do
@@ -58,7 +63,7 @@ RSpec.describe FileIdentifierService do
 
       it 'returns pronom id and mimetype' do
         expect(identifiers).to eq(['x-fmt/111', 'text/plain'])
-        expect(Open3).to have_received(:capture2e).with('sf', '-json', 'bar.txt')
+        expect(Open3).to have_received(:capture3).with('sf', '-json', 'bar.txt')
       end
     end
 
@@ -92,12 +97,8 @@ RSpec.describe FileIdentifierService do
     context 'when siegfried reports an error' do
       let(:identifiers) { service.identify(filepath: 'bar.zip') }
 
-      let(:output) do
-        <<~OUTPUT
-          [ERROR] zip: not a valid zip file
-          {"siegfried":"1.8.0","scandate":"2020-04-01T07:04:16-07:00","signature":"default.sig","created":"2020-01-21T23:30:42+01:00","identifiers":[{"name":"pronom","details":"DROID_SignatureFile_V96.xml; container-signature-20200121.xml"}],"files":[{"filename":"bar.zip","filesize": 8372334239,"modified":"2020-03-30T22:43:14-07:00","errors": "zip: not a valid zip file","matches": [{"ns":"pronom","id":"x-fmt/263","format":"ZIP Format","version":"","mime":"application/zip","basis":"extension match zip; byte match at [[0 4] [8372334131 3] [8372334217 4]]","warning":""}]}]}
-        OUTPUT
-      end
+      let(:output) { '{"siegfried":"1.8.0","scandate":"2020-04-01T07:04:16-07:00","signature":"default.sig","created":"2020-01-21T23:30:42+01:00","identifiers":[{"name":"pronom","details":"DROID_SignatureFile_V96.xml; container-signature-20200121.xml"}],"files":[{"filename":"bar.zip","filesize": 8372334239,"modified":"2020-03-30T22:43:14-07:00","errors": "zip: not a valid zip file","matches": [{"ns":"pronom","id":"x-fmt/263","format":"ZIP Format","version":"","mime":"application/zip","basis":"extension match zip; byte match at [[0 4] [8372334131 3] [8372334217 4]]","warning":""}]}]}' }
+      let(:err) { '[ERROR] zip: not a valid zip file' }
 
       let(:status) { instance_double(Process::Status, success?: true) }
 


### PR DESCRIPTION
## Why was this change made?
Cleaner to use capture3 then parse output.


## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?
No


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
No