### PR TITLE
Deploy additional workers

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -46,4 +46,6 @@ before 'deploy:restart', 'shared_configs:update'
 # Sidekiq configuration (run three processes)
 # see sidekiq.yml for concurrency and queue settings
 set :sidekiq_env, 'production'
+set :sidekiq_roles, :worker
+set :passenger_roles, :web
 set :sidekiq_processes, 3

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 server 'dor-techmd-prod.stanford.edu', user: 'techmd', roles: %w[web app db]
+server 'dor-techmd-worker-prod-a.stanford.edu', user: 'techmd', roles: %w[app worker]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-server 'dor-techmd-stage.stanford.edu', user: 'techmd', roles: %w[web app db]
+server 'dor-techmd-stage.stanford.edu', user: 'techmd', roles: %w[web app db worker]
+# This server doesn't exist yet.
+# server 'dor-techmd-worker-stage-a.stanford.edu', user: 'techmd', roles: %w[app worker]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
-Sidekiq.configure_server do |_config|
+Sidekiq.configure_server do |config|
+  config.redis = { url: Settings.redis_url }
   ActiveRecord::Base.logger = Sidekiq::Logging.logger
   Rails.logger = Sidekiq::Logging.logger
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: Settings.redis_url }
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,3 +5,5 @@ hmac_secret: 'my$ecretK3y'
 
 storage_root_map: # empty here, override in #{RAILS_ENV}.yml
   default: {}
+
+redis_url: redis://localhost:6379/


### PR DESCRIPTION
Depends on https://github.com/sul-dlss/shared_configs/pull/1307 and https://github.com/sul-dlss/shared_configs/pull/1306

## Why was this change made?
This deploys to the additional worker server.

## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?

no

## Does this change affect how this application integrates with other services?
no
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
