### PR TITLE
allow dates with colons to parse

### DIFF
--- a/app/services/av_characterizer_service.rb
+++ b/app/services/av_characterizer_service.rb
@@ -128,10 +128,12 @@ class AvCharacterizerService
 
   # @param [String] time a date with format like 'UTC 2020-02-27 06:06:04' - although sometimes UTC doesn't come through
   def to_iso_time(time)
+    time.gsub!(/[:-]/, '') # strips : or - in date and time parts to handle cases where the date has colons or dashes
+
     unless time.start_with?('UTC')
-      return Time.strptime("#{time}+0000", '%Y-%m-%d %H:%M:%S%z').iso8601.delete_suffix('+00:00')
+      return Time.strptime("#{time}+0000", '%Y%m%d %H%M%S%z').iso8601.delete_suffix('+00:00')
     end
 
-    Time.strptime("#{time}+0000", 'UTC %Y-%m-%d %H:%M:%S%z').iso8601
+    Time.strptime("#{time}+0000", 'UTC %Y%m%d %H%M%S%z').iso8601
   end
 end

--- a/app/services/av_characterizer_service.rb
+++ b/app/services/av_characterizer_service.rb
@@ -129,11 +129,9 @@ class AvCharacterizerService
   # @param [String] time a date with format like 'UTC 2020-02-27 06:06:04' - although sometimes UTC doesn't come through
   def to_iso_time(time)
     time.gsub!(/[:-]/, '') # strips : or - in date and time parts to handle cases where the date has colons or dashes
+    date_format = '%Y%m%d %H%M%S%z'
+    return Time.strptime("#{time}+0000", date_format).iso8601.delete_suffix('+00:00') unless time.start_with?('UTC')
 
-    unless time.start_with?('UTC')
-      return Time.strptime("#{time}+0000", '%Y%m%d %H%M%S%z').iso8601.delete_suffix('+00:00')
-    end
-
-    Time.strptime("#{time}+0000", 'UTC %Y%m%d %H%M%S%z').iso8601
+    Time.strptime("#{time}+0000", "UTC #{date_format}").iso8601
   end
 end

--- a/spec/services/av_characterizer_service_spec.rb
+++ b/spec/services/av_characterizer_service_spec.rb
@@ -111,8 +111,36 @@ RSpec.describe AvCharacterizerService do
         end
       end
 
+      context 'when date has a colon in the date part and is UTC' do
+        let(:encoded_date) { '"UTC 2020:02:27 18:23:48"' }
+
+        it 'returns av_metadata and track metadata' do
+          expect(characterization).to eq([{ audio_count: 1, file_extension: 'ogg', format: 'Ogg', duration: 1.002,
+                                            encoded_date: '2020-02-27T18:23:48+00:00' },
+                                          [{ part_type: 'audio', part_id: '28470', order: nil, format: 'Vorbis',
+                                             audio_metadata: { channels: '1', sampling_rate: 44_100,
+                                                               stream_size: 10_020 },
+                                             video_metadata: nil, other_metadata: nil }]])
+          expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', 'noam.ogg')
+        end
+      end
+
       context 'when date does not have a timezone' do
         let(:encoded_date) { '"2020-02-27 18:23:48"' }
+
+        it 'returns av_metadata and track metadata' do
+          expect(characterization).to eq([{ audio_count: 1, file_extension: 'ogg', format: 'Ogg', duration: 1.002,
+                                            encoded_date: '2020-02-27T18:23:48' },
+                                          [{ part_type: 'audio', part_id: '28470', order: nil, format: 'Vorbis',
+                                             audio_metadata: { channels: '1', sampling_rate: 44_100,
+                                                               stream_size: 10_020 },
+                                             video_metadata: nil, other_metadata: nil }]])
+          expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', 'noam.ogg')
+        end
+      end
+
+      context 'when date has colons in the date part and does not have a timezone' do
+        let(:encoded_date) { '"2020:02:27 18:23:48"' }
 
         it 'returns av_metadata and track metadata' do
           expect(characterization).to eq([{ audio_count: 1, file_extension: 'ogg', format: 'Ogg', duration: 1.002,


### PR DESCRIPTION
## Why was this change made?

fix #131 
also, reduce duplication of code specifying date format

## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?



## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
