### PR TITLE
Switch to sidekiq 6 using systemd

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -15,7 +15,6 @@ require 'capistrano/honeybadger'
 require 'capistrano/passenger'
 require 'capistrano/rails'
 require 'dlss/capistrano'
-require 'capistrano/sidekiq'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'jbuilder'
 gem 'jwt'
 gem 'okcomputer'
 gem 'pg'
-gem 'sidekiq', '~> 5.2'
+gem 'sidekiq', '~> 6.0'
 gem 'sidekiq-statistic'
 gem 'webpacker', '~> 4.0'
 
@@ -52,6 +52,5 @@ end
 group :deployment do
   gem 'capistrano-passenger', require: false
   gem 'capistrano-rails', require: false
-  gem 'capistrano-sidekiq', require: false
   gem 'dlss-capistrano', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,9 +85,6 @@ GEM
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
     capistrano-shared_configs (0.2.2)
-    capistrano-sidekiq (1.0.3)
-      capistrano (>= 3.9.0)
-      sidekiq (>= 3.4, < 6.0)
     committee (3.3.0)
       json_schema (~> 0.14, >= 0.14.3)
       openapi_parser (>= 0.6.1)
@@ -211,7 +208,7 @@ GEM
     pg (1.2.3)
     puma (4.3.3)
       nio4r (~> 2.0)
-    rack (2.0.9)
+    rack (2.2.2)
     rack-protection (2.0.8.1)
       rack
     rack-proxy (0.6.5)
@@ -284,11 +281,11 @@ GEM
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
-    sidekiq (5.2.8)
-      connection_pool (~> 2.2, >= 2.2.2)
-      rack (< 2.1.0)
-      rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 5)
+    sidekiq (6.0.6)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      rack-protection (>= 2.0.0)
+      redis (>= 4.1.0)
     sidekiq-statistic (1.4.0)
       sidekiq (>= 5.0)
       tilt (~> 2.0)
@@ -334,7 +331,6 @@ DEPENDENCIES
   byebug
   capistrano-passenger
   capistrano-rails
-  capistrano-sidekiq
   committee
   config
   dlss-capistrano
@@ -353,7 +349,7 @@ DEPENDENCIES
   rubocop (~> 0.79.0)
   rubocop-rails
   rubocop-rspec
-  sidekiq (~> 5.2)
+  sidekiq (~> 6.0)
   sidekiq-statistic
   simplecov (~> 0.17.1)
   spring

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -40,12 +40,12 @@ set :linked_dirs, %w[log config/settings vendor/bundle public/system tmp/pids]
 # honeybadger_env otherwise defaults to rails_env
 set :honeybadger_env, fetch(:stage)
 
+set :passenger_roles, :web
+
 # update shared_configs before restarting app
 before 'deploy:restart', 'shared_configs:update'
-
-# Sidekiq configuration (run three processes)
-# see sidekiq.yml for concurrency and queue settings
-set :sidekiq_env, 'production'
-set :sidekiq_roles, :worker
-set :passenger_roles, :web
-set :sidekiq_processes, 3
+# These hooks are from capistrano-sidekiq but the sidekiq tasks themselves are defined in dor-services-app
+after 'deploy:starting',  'sidekiq:quiet'
+after 'deploy:updated',   'sidekiq:stop'
+after 'deploy:published', 'sidekiq:start'
+after 'deploy:failed', 'sidekiq:restart'

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+namespace :sidekiq do
+  desc 'Quiet Sidekiq (stop fetching new tasks from Redis)'
+  task :quiet do
+    on roles(:worker) do
+      sudo :systemctl, 'reload', 'sidekiq-*', raise_on_non_zero_exit: false
+    end
+  end
+
+  desc 'Stop Sidekiq (graceful shutdown within timeout, put unfinished tasks back to Redis)'
+  task :stop do
+    on roles(:worker) do
+      sudo :systemctl, 'stop', 'sidekiq-*'
+    end
+  end
+
+  desc 'Start Sidekiq'
+  task :start do
+    on roles(:worker) do
+      sudo :systemctl, 'start', 'sidekiq-*'
+    end
+  end
+
+  desc 'Restart Sidekiq'
+  task :restart do
+    on roles(:worker) do
+      sudo :systemctl, 'restart', 'sidekiq-*', raise_on_non_zero_exit: false
+    end
+  end
+end


### PR DESCRIPTION
As part of this, remove capistrano-sidekiq dependency (because incompatible with our systemd-ified sidekiq configuration in puppet) and create a new task for restarting sidekiq.

## Why was this change made?

To keep pace with Sidekiq.

## Was the API documentation (openapi.yml) updated?

No.

## Does this change affect how this application integrates with other services?

No.