### PR TITLE
Use 6.x style logger initialization

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,8 +2,8 @@
 
 Sidekiq.configure_server do |config|
   config.redis = { url: Settings.redis_url }
-  ActiveRecord::Base.logger = Sidekiq::Logging.logger
-  Rails.logger = Sidekiq::Logging.logger
+  ActiveRecord::Base.logger = Sidekiq.logger
+  Rails.logger = Sidekiq.logger
 end
 
 Sidekiq.configure_client do |config|

--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -18,7 +18,7 @@ namespace :sidekiq do
   desc 'Start Sidekiq'
   task :start do
     on roles(:worker) do
-      sudo :systemctl, 'start', 'sidekiq-*'
+      sudo :systemctl, 'start', 'sidekiq-*', '--all'
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

Fixes an error starting sidekiq because of the old logger config

## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?

N/A


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.

stage