### PR TITLE
Run yarn install when building docker image

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -8,18 +8,19 @@ RUN apk add --update --no-cache  \
   build-base \
   postgresql-dev \
   postgresql-client \
-  tzdata
+  tzdata \
+  yarn
 
 # Get bundler 2.0
 RUN gem install bundler
 
-RUN mkdir /app
 WORKDIR /app
 
-COPY Gemfile Gemfile.lock ./
+COPY Gemfile Gemfile.lock package.json yarn.lock ./
 
-RUN bundle config set without 'production'
-RUN bundle install
+RUN bundle config set without 'production' && \
+  bundle install && \
+  yarn install
 
 COPY . .
 


### PR DESCRIPTION
## Why was this change made?

The techmd service, e.g., in Argo's docker-compose configuration, will not start up without this.

## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?

No.

## Does this change affect how this application integrates with other services?

No.