### PR TITLE
Sets ruby version to 2.7.1.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
 jobs:
   test:
     docker:
-    - image: circleci/ruby:2.7.0-node
+    - image: circleci/ruby:2.7.1-node
       environment:
         BUNDLE_JOBS: 3
         BUNDLE_RETRY: 3

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is optimized for running in development. That means it trades
 # build speed for size. If we were using this for production, we might instead
 # optimize for a smaller size at the cost of a slower build.
-FROM ruby:2.7.0-alpine
+FROM ruby:2.7.1-alpine
 
 # postgresql-client is required for invoke.sh
 RUN apk add --update --no-cache  \

--- a/docker/workers/Dockerfile
+++ b/docker/workers/Dockerfile
@@ -4,7 +4,7 @@
 #
 # NOTE: This uses a Debian-based image rather than an Alpine-based image so that
 #       we can install Debian packages. In particular: siegfried.
-FROM ruby:2.7.0-buster
+FROM ruby:2.7.1-buster
 
 # postgresql-client is required for invoke.sh
 RUN curl -sS https://bintray.com/user/downloadSubjectPublicKey?username=bintray | apt-key add - && \


### PR DESCRIPTION
## Why was this change made?
Update to ruby 2.7.1


## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?



## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
