### PR TITLE
Handles unparseable dates.

### DIFF
--- a/app/services/av_characterizer_service.rb
+++ b/app/services/av_characterizer_service.rb
@@ -128,7 +128,7 @@ class AvCharacterizerService
   end
 
   # @param [String,nil] time a date with format like 'UTC 2020-02-27 06:06:04' or nil if blank or unparseable.
-  # Note that time may not include UTC.
+  # @note time may not include UTC.
   def to_iso_time(time)
     return nil if time.blank?
 

--- a/app/services/av_characterizer_service.rb
+++ b/app/services/av_characterizer_service.rb
@@ -68,7 +68,8 @@ class AvCharacterizerService
       metadata[:codec_id] = track['CodecID'] if track['CodecID'].present?
       metadata[:duration] = track['Duration'].to_f if track['Duration'].present?
       metadata[:frame_rate] = track['FrameRate'].to_f if track['FrameRate'].present?
-      metadata[:encoded_date] = to_iso_time(track['Encoded_Date']) if track['Encoded_Date'].present?
+      encoded_date = to_iso_time(track['Encoded_Date'])
+      metadata[:encoded_date] = encoded_date if encoded_date
     end
   end
 
@@ -126,12 +127,17 @@ class AvCharacterizerService
     }
   end
 
-  # @param [String] time a date with format like 'UTC 2020-02-27 06:06:04' - although sometimes UTC doesn't come through
+  # @param [String,nil] time a date with format like 'UTC 2020-02-27 06:06:04' or nil if blank or unparseable.
+  # Note that time may not include UTC.
   def to_iso_time(time)
+    return nil if time.blank?
+
     time.gsub!(/[:-]/, '') # strips : or - in date and time parts to handle cases where the date has colons or dashes
     date_format = '%Y%m%d %H%M%S%z'
     return Time.strptime("#{time}+0000", date_format).iso8601.delete_suffix('+00:00') unless time.start_with?('UTC')
 
     Time.strptime("#{time}+0000", "UTC #{date_format}").iso8601
+  rescue ArgumentError
+    nil
   end
 end

--- a/spec/services/av_characterizer_service_spec.rb
+++ b/spec/services/av_characterizer_service_spec.rb
@@ -152,6 +152,19 @@ RSpec.describe AvCharacterizerService do
           expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', 'noam.ogg')
         end
       end
+
+      context 'when unparseable date' do
+        let(:encoded_date) { '"2017.05.10 193630+0000"' }
+
+        it 'returns av_metadata and track metadata' do
+          expect(characterization).to eq([{ audio_count: 1, file_extension: 'ogg', format: 'Ogg', duration: 1.002 },
+                                          [{ part_type: 'audio', part_id: '28470', order: nil, format: 'Vorbis',
+                                             audio_metadata: { channels: '1', sampling_rate: 44_100,
+                                                               stream_size: 10_020 },
+                                             video_metadata: nil, other_metadata: nil }]])
+          expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', 'noam.ogg')
+        end
+      end
     end
 
     context 'when video file is characterized' do


### PR DESCRIPTION
closes #152

## Why was this change made?
To handle unparseable dates in files.


## Was the usage documentation (e.g. openapi.yml, README, DevOpsDocs) updated?
No


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
No