### PR TITLE
Mark PDFs with invalid byte sequences to indicate there is no text available

### DIFF
--- a/app/services/pdf_characterizer_service.rb
+++ b/app/services/pdf_characterizer_service.rb
@@ -39,6 +39,13 @@ class PdfCharacterizerService
     raise Error, "Extracting text from #{filepath} returned #{status.exitstatus}: #{output}" unless status.success?
 
     output.present?
+  rescue ArgumentError => e
+    # Some ETDs have PDFs with encoding problems, which means they don't have
+    # text we can meaningfully interact with. Andrew Berger says this should
+    # return `false` in these instances.
+    return false if e.message.match?('invalid byte sequence')
+
+    raise e
   end
 
   # rubocop:disable Metrics/AbcSize


### PR DESCRIPTION
## Why was this change made?

Adding this code to be able to account for e.g. ETD PDFs with weirdo encoding issues. Andrew Berger says this is the desired behavior.

## How was this change tested?

Unit tests.

## Which documentation and/or configurations were updated?

None.

