### PR TITLE
Add QA deployment environment

### DIFF
--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+server 'dor-techmd-qa.stanford.edu', user: 'techmd', roles: %w[web app db worker]
+server 'dor-techmd-worker-qa-a.stanford.edu', user: 'techmd', roles: %w[app worker]
+
+Capistrano::OneTimeKey.generate_one_time_key!
+set :rails_env, 'production'


### PR DESCRIPTION
## Why was this change made?

The boxes exist and Argo does not work well in QA without this service in place. Let us begin deploying there!

## How was this change tested?

I ran `cap qa ssh` and `cap qa deploy` and they worked.

## Which documentation and/or configurations were updated?

Added/updated shared_configs.