### PR TITLE
Configure Host Authorization for argo testing

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -53,4 +53,9 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :sidekiq
+
+  # configure Host Authorization middleware.
+  # Allow the application to be named 'techmd' so that this container can be run
+  # by argo in circle-ci
+  config.hosts << 'techmd'
 end


### PR DESCRIPTION
## Why was this change made?
Previously the middleware was configured so that argo could not connect to it in a docker network.  See https://app.circleci.com/pipelines/github/sul-dlss/argo/295/workflows/9e10dd85-dee0-4f06-b878-7e5f2d4ebb53/jobs/340

## How was this change tested?



## Which documentation and/or configurations were updated?



