### PR TITLE
Switches datatype to number for height and width properties in openapi.

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -195,10 +195,11 @@ components:
       description: Image-specific technical metadata
       type: object
       properties:
+        # Some image formats, e.g., SVG return floats for height and width, hence type: number
         height:
-          type: integer
+          type: number
         width:
-          type: integer
+          type: number
     OtherAvMetadata:
       description: Other technical metadata for a file part
       type: object


### PR DESCRIPTION
closes #208

## Why was this change made?
So that the openapi matches the data and does not cause an error to be raised.


## How was this change tested?
Tested by production deploy.


## Which documentation and/or configurations were updated?
openapi


