### PR TITLE
use default rails logger for dor-workflow-client

### DIFF
--- a/app/jobs/technical_metadata_workflow_job.rb
+++ b/app/jobs/technical_metadata_workflow_job.rb
@@ -38,6 +38,6 @@ class TechnicalMetadataWorkflowJob < ApplicationJob
   end
 
   def client
-    @client ||= Dor::Workflow::Client.new(url: Settings.workflow.url)
+    @client ||= Dor::Workflow::Client.new(url: Settings.workflow.url, logger: Rails.logger)
   end
 end


### PR DESCRIPTION
## Why was this change made?

An attempt to address #229 - the ongoing HB alerting of a non-existent workflow_service.log.  Let's see if telling the dor-workflow-client to use the default rails logger instead of creating its own helps.

## How was this change tested?



## Which documentation and/or configurations were updated?



