### PR TITLE
allows us to do bin/rails in production

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ require:
 AllCops:
   Exclude:
     - 'bin/bundle'
+    - 'bin/spring'
     - 'vendor/**/*'
     - 'db/schema.rb'
     - 'db/migrate/*.rb'

--- a/bin/spring
+++ b/bin/spring
@@ -2,11 +2,14 @@
 # frozen_string_literal: true
 
 if !defined?(Spring) && [nil, 'development', 'test'].include?(ENV['RAILS_ENV'])
-  # Load Spring without loading other gems in the Gemfile, for speed.
   require 'bundler'
+
+  # Load Spring without loading other gems in the Gemfile, for speed.
   Bundler.locked_gems.specs.find { |spec| spec.name == 'spring' }&.tap do |spring|
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
     gem 'spring', spring.version
     require 'spring/binstub'
+  rescue Gem::LoadError
+  # Ignore when Spring is not installed.
   end
 end


### PR DESCRIPTION
## Why was this change made?

So we can run rails console in production without spring installed.  Analog to https://github.com/sul-dlss/happy-heron/commit/e832a0556abbf9a92214d083261b50184004a458

## How was this change tested?



## Which documentation and/or configurations were updated?



