### PR TITLE
Fix docker build within circle.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,9 @@ jobs:
     executor: docker-publisher
     steps:
     - checkout
-    - setup_remote_docker
+    - setup_remote_docker:
+        # Setting docker version per https://support.circleci.com/hc/en-us/articles/360050934711-Docker-build-fails-with-EPERM-operation-not-permitted-copyfile-when-using-node-14-9-0-or-later-
+        version: 19.03.13
     - run:
         name: Build Docker image
         command: |
@@ -140,7 +142,9 @@ jobs:
     steps:
     - attach_workspace:
         at: /tmp/workspace
-    - setup_remote_docker
+    - setup_remote_docker:
+        # Setting docker version per https://support.circleci.com/hc/en-us/articles/360050934711-Docker-build-fails-with-EPERM-operation-not-permitted-copyfile-when-using-node-14-9-0-or-later-
+        version: 19.03.13
     - run:
         name: Load archived Docker image
         command: |
@@ -155,7 +159,9 @@ jobs:
     steps:
     - attach_workspace:
         at: /tmp/workspace
-    - setup_remote_docker
+    - setup_remote_docker:
+        # Setting docker version per https://support.circleci.com/hc/en-us/articles/360050934711-Docker-build-fails-with-EPERM-operation-not-permitted-copyfile-when-using-node-14-9-0-or-later-
+        version: 19.03.13
     - run:
         name: Load archived Docker image
         command: |


### PR DESCRIPTION
## Why was this change made?
Building docker images within circle was failing. See, for example, https://app.circleci.com/pipelines/github/sul-dlss/technical-metadata-service/444/workflows/6cd0b441-8c16-4a45-8fa9-856d7e78f16b/jobs/728


## How was this change tested?
NA


## Which documentation and/or configurations were updated?
NA


