### PR TITLE
Decommission techmd-worker-stage-b

### DIFF
--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -2,7 +2,6 @@
 
 server 'dor-techmd-stage.stanford.edu', user: 'techmd', roles: %w[web app db worker]
 server 'dor-techmd-worker-stage-a.stanford.edu', user: 'techmd', roles: %w[app worker]
-server 'dor-techmd-worker-stage-b.stanford.edu', user: 'techmd', roles: %w[app worker]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'


### PR DESCRIPTION
## Why was this change made?

worker-stage-b was a temporary replacement while rebuilding worker-stage-a as Ubuntu

## How was this change tested?

N/A

## Which documentation and/or configurations were updated?

N/A

