### PR TITLE
Fixes deployment to Ubuntu for web role

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -46,3 +46,7 @@ set :sidekiq_systemd_use_hooks, true
 
 # update shared_configs before restarting app
 before 'deploy:restart', 'shared_configs:update'
+
+# Workaround for "Rails assets manifest file not found"
+# error thrown when deploying the web role to Ubuntu
+Rake::Task['deploy:assets:backup_manifest'].clear_actions


### PR DESCRIPTION
## Why was this change made?

The deployment to an Ubuntu machine with the web role defined couldn't find the Rails asset manifest file 

## How was this change tested?

Deployed successfully to dor-techmd-stage (CentOS) and an eventual Ubuntu replacement

## Which documentation and/or configurations were updated?

N/A

