### PR TITLE
Skip installing the postgresql-client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,13 +71,6 @@ jobs:
         name: Check styles using rubocop
         command: bundle exec rubocop
 
-    # Need `psql` command when you store the app schema as SQL instead of as Ruby
-    - run:
-        name: Install postgresql client
-        command: |
-          sudo apt update -y
-          sudo apt install -y postgresql-client || true
-
     - run:
         name: Wait for DB
         command: dockerize -wait tcp://localhost:5432 -timeout 1m


### PR DESCRIPTION


## Why was this change made?
Make the build faster.


## How was this change tested?



## Which documentation and/or configurations were updated?



