### PR TITLE
Remove bootstrap javascript

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,2 +1,1 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-import Bootstrap from "bootstrap";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/css/bootstrap.min.css" integrity="sha384-zCbKRCUGaJDkqS1kPbPd7TveP5iyJE0EjAuZQTgFLD2ylzuqKfdKlfG/eSrtxUkn" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <%= javascript_importmap_tags %>
   </head>
 

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -3,6 +3,3 @@
 # Pin npm packages by running ./bin/importmap
 
 pin 'application', preload: true
-pin 'bootstrap', to: 'https://ga.jspm.io/npm:bootstrap@4.4.1/dist/js/bootstrap.js'
-pin 'jquery', to: 'https://ga.jspm.io/npm:jquery@3.6.0/dist/jquery.js'
-pin 'popper.js', to: 'https://ga.jspm.io/npm:popper.js@1.16.1/dist/umd/popper.js'


### PR DESCRIPTION
Upgrade bootstrap styles to 5.



## Why was this change made?
We don't use the bootstrap javascript, so there's no sense in downloading it


## How was this change tested?



## Which documentation and/or configurations were updated?



