### PR TITLE
simplecov gem no longer needs version restriction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ group :development, :test do
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
-  gem 'simplecov', '~> 0.17.1' # 0.18 breaks reporting https://github.com/codeclimate/test-reporter/issues/418
+  gem 'simplecov', '~> 0.21'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -344,11 +344,12 @@ GEM
     sidekiq-statistic (1.4.0)
       sidekiq (>= 5.0)
       tilt (~> 2.0)
-    simplecov (0.17.1)
+    simplecov (0.21.2)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.3)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -408,7 +409,7 @@ DEPENDENCIES
   rubocop-rspec
   sidekiq (~> 6.0)
   sidekiq-statistic
-  simplecov (~> 0.17.1)
+  simplecov (~> 0.21)
   spring
   spring-watcher-listen (~> 2.0.0)
   sprockets-rails


### PR DESCRIPTION
## Why was this change made?

cleaner, simpler makes me happy.

## How was this change tested?

circleci build going to codeclimate.

## Which documentation and/or configurations were updated?



