### PR TITLE
Add new server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,3 +179,10 @@ Publish:
 ```
 docker push suldlss/technical-metadata-service:latest
 ```
+
+## Deploy
+There is a separate production deploy environment called "retro" that deploys to dor-techmd-worker-prod-b.stanford.edu.
+
+The workers on this server only take jobs from the "retro" queue; these jobs require reading from preservation storage.
+Due to permissions issues, this must be performed as the "pres" user. Due to limitations in capistrano, this requires
+a separate deploy environment.

--- a/config/deploy/retro.rb
+++ b/config/deploy/retro.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Note that running this as pres user due to read file permissions issues as techmd user.
+server 'dor-techmd-worker-prod-b.stanford.edu', user: 'pres', roles: %w[app worker]
+
+Capistrano::OneTimeKey.generate_one_time_key!
+set :rails_env, 'production'
+set :deploy_to, '/opt/app/pres/dor_techmd'

--- a/config/retro_sidekiq.yml
+++ b/config/retro_sidekiq.yml
@@ -1,0 +1,3 @@
+:concurrency: 4
+:queues:
+  - retro


### PR DESCRIPTION
## Why was this change made? 🤔
Add new prod server to support retro techmd generation.


## How was this change tested? 🤨

⚡ ⚠ If this change consumes from or writes to other services (including shared file systems), ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test) on stage as it exercises this service*** and/or test in [stage|qa] environment, in addition to specs.  ***You will need to confirm that technical metadata was correctly created for the test, as it is a background job kicked off by a common-accessioning step.***⚡


