### PR TITLE
bump sul-dlss circleci orb to 3.1.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby-rails: sul-dlss/ruby-rails@2.0.0
+  ruby-rails: sul-dlss/ruby-rails@3.1.2
 workflows:
   build:
     jobs:


### PR DESCRIPTION
## Why was this change made? 🤔

Let's ensure we run ALL the specs.

## How was this change tested? 🤨

⚡ ⚠ If this change consumes from or writes to other services (including shared file systems), ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test) on stage as it exercises this service*** and/or test in [stage|qa] environment, in addition to specs.  ***You will need to confirm that technical metadata was correctly created for the test, as it is a background job kicked off by a common-accessioning step.***⚡


