### PR TITLE
Switch from sprockets-rails to propshaft

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,9 @@ gem 'jbuilder'
 gem 'jwt'
 gem 'okcomputer'
 gem 'pg'
+gem 'propshaft'
 gem 'sidekiq', '~> 6.0'
 gem 'sidekiq-statistic'
-gem 'sprockets-rails'
 gem 'turbo-rails'
 
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,6 +232,11 @@ GEM
     parser (3.1.2.0)
       ast (~> 2.4.1)
     pg (1.4.2)
+    propshaft (0.6.4)
+      actionpack (>= 7.0.0)
+      activesupport (>= 7.0.0)
+      rack
+      railties (>= 7.0.0)
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -331,13 +336,6 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (4.1.1)
-      concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
-    sprockets-rails (3.4.2)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
-      sprockets (>= 3.0.0)
     sshkit (1.21.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
@@ -380,6 +378,7 @@ DEPENDENCIES
   moab-versioning
   okcomputer
   pg
+  propshaft
   puma (~> 5.6)
   rails (~> 7.0.1)
   rspec-rails
@@ -393,7 +392,6 @@ DEPENDENCIES
   simplecov (~> 0.21)
   spring
   spring-watcher-listen (~> 2.0.0)
-  sprockets-rails
   turbo-rails
 
 BUNDLED WITH


### PR DESCRIPTION


## Why was this change made? 🤔
We don't need the transpiling that sprockets-rails does, so propshaft is a lighter dependency


## How was this change tested? 🤨
Deployed to qa

