### PR TITLE
Set the query-hash-key to avoid deprecation warnings

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -62,6 +62,7 @@ module TechnicalMetadataService
                           query_hash_key: 'action_dispatch.request.query_parameters'
     config.middleware.use Committee::Middleware::ResponseValidation,
                           schema_path: 'openapi.yml',
-                          parse_response_by_content_type: false
+                          parse_response_by_content_type: false,
+                          query_hash_key: 'rack.request.query_hash'
   end
 end


### PR DESCRIPTION


## Why was this change made? 🤔

Fixes #190

## How was this change tested? 🤨

⚡ ⚠ If this change consumes from or writes to other services (including shared file systems), ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test) on stage as it exercises this service*** and/or test in [stage|qa] environment, in addition to specs.  ***You will need to confirm that technical metadata was correctly created for the test, as it is a background job kicked off by a common-accessioning step.***⚡


