### PR TITLE
Change retro concurrency to 1.

### DIFF
--- a/config/retro_sidekiq.yml
+++ b/config/retro_sidekiq.yml
@@ -1,3 +1,3 @@
-:concurrency: 2
+:concurrency: 1
 :queues:
   - retro


### PR DESCRIPTION
## Why was this change made? 🤔
ceph-friendly. Trying changing from 2 processes with 2 threads to 4 processes with 1 thread.


## How was this change tested? 🤨

⚡ ⚠ If this change consumes from or writes to other services (including shared file systems), ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test) on stage as it exercises this service*** and/or test in [stage|qa] environment, in addition to specs.  ***You will need to confirm that technical metadata was correctly created for the test, as it is a background job kicked off by a common-accessioning step.***⚡


