### PR TITLE
Remove capistrano-rvm dependency

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -15,7 +15,6 @@ require 'capistrano/honeybadger'
 require 'capistrano/passenger'
 require 'capistrano/rails'
 require 'dlss/capistrano'
-require 'capistrano/rvm'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,6 @@ end
 group :deployment do
   gem 'capistrano-passenger', require: false
   gem 'capistrano-rails', require: false
-  gem 'capistrano-rvm', require: false # for Ubuntu deployments
   gem 'dlss-capistrano', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,9 +94,6 @@ GEM
     capistrano-rails (1.6.2)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
-    capistrano-rvm (0.1.2)
-      capistrano (~> 3.0)
-      sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     committee (4.4.0)
       json_schema (~> 0.14, >= 0.14.3)
@@ -364,7 +361,6 @@ DEPENDENCIES
   byebug
   capistrano-passenger
   capistrano-rails
-  capistrano-rvm
   committee
   config
   dlss-capistrano
@@ -394,4 +390,4 @@ DEPENDENCIES
   turbo-rails
 
 BUNDLED WITH
-   2.3.17
+   2.3.13

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -40,10 +40,6 @@ set :linked_dirs, %w[log config/settings vendor/bundle public/system tmp/pids]
 # honeybadger_env otherwise defaults to rails_env
 set :honeybadger_env, fetch(:stage)
 
-# the honeybadger gem should integrate automatically with capistrano-rvm but it
-# doesn't appear to do so on our new Ubuntu boxes :shrug:
-set :rvm_map_bins, fetch(:rvm_map_bins, []).push('honeybadger')
-
 set :passenger_roles, :web
 set :sidekiq_systemd_role, :worker
 set :sidekiq_systemd_use_hooks, true


### PR DESCRIPTION
## Why was this change made? 🤔

This commit removes capistrano-rvm, a dependency we no longer need. Done because it is on the FR board.



## How was this change tested? 🤨

Tested with stage deploy
