### PR TITLE
Remove sidekiq-statistic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ gem 'okcomputer'
 gem 'pg'
 gem 'propshaft'
 gem 'sidekiq', '~> 6.0'
-gem 'sidekiq-statistic'
 gem 'turbo-rails'
 
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,9 +317,6 @@ GEM
       connection_pool (>= 2.2.5)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
-    sidekiq-statistic (1.4.0)
-      sidekiq (>= 5.0)
-      tilt (~> 2.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -334,7 +331,6 @@ GEM
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     thor (1.2.1)
-    tilt (2.0.11)
     timeout (0.3.0)
     turbo-rails (1.3.2)
       actionpack (>= 6.0.0)
@@ -380,11 +376,10 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   sidekiq (~> 6.0)
-  sidekiq-statistic
   simplecov (~> 0.21)
   spring
   spring-watcher-listen (~> 2.0.0)
   turbo-rails
 
 BUNDLED WITH
-   2.3.22
+   2.3.25


### PR DESCRIPTION

## Why was this change made? 🤔

Closes #401

## How was this change tested? 🤨

⚡ ⚠ If this change consumes from or writes to other services (including shared file systems), ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test) on stage as it exercises this service*** and/or test in [stage|qa] environment, in addition to specs.  ***You will need to confirm that technical metadata was correctly created for the test, as it is a background job kicked off by a common-accessioning step.***⚡


