### PR TITLE
Adds redis gem for OKComputer check.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'jwt'
 gem 'okcomputer'
 gem 'pg'
 gem 'propshaft'
+gem 'redis', '~>4.8' # For OKComputer check
 gem 'sidekiq', '~> 7.0'
 gem 'turbo-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,6 +269,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.8.1)
     redis-client (0.14.0)
       connection_pool
     regexp_parser (2.7.0)
@@ -375,6 +376,7 @@ DEPENDENCIES
   propshaft
   puma (~> 5.6)
   rails (~> 7.0.1)
+  redis (~> 4.8)
   rspec-rails
   rspec_junit_formatter
   rubocop


### PR DESCRIPTION
## Why was this change made? 🤔
So OKComputer checks work.


## How was this change tested? 🤨

⚡ ⚠ If this change consumes from or writes to other services (including shared file systems), ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test) on stage as it exercises this service*** and/or test in [stage|qa] environment, in addition to specs.  ***You will need to confirm that technical metadata was correctly created for the test, as it is a background job kicked off by a common-accessioning step.***⚡

Stage
