### PR TITLE
Disentangle development and test databases

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -11,9 +11,11 @@ default: &default
 
 development:
   <<: *default
+  database: "<%= ENV.fetch('DATABASE_NAME', 'technical_metadata_development') %>"
 
 test:
   <<: *default
+  database: "<%= ENV.fetch('DATABASE_NAME', 'technical_metadata_test') %>"
 
 production:
   <<: *default


### PR DESCRIPTION
## Why was this change made? 🤔

technical-metadata-service is an outlier among our applications in that it re-uses the same DB across environments, a Rails anti-pattern. Now Rails should complain at us less. This commit only affects CI and local development, not deployed instances.


## How was this change tested? 🤨

CI
