### PR TITLE
put workflow step into error state if exception occurs

### DIFF
--- a/app/jobs/technical_metadata_workflow_job.rb
+++ b/app/jobs/technical_metadata_workflow_job.rb
@@ -16,6 +16,9 @@ class TechnicalMetadataWorkflowJob < ApplicationJob
     else
       log_failure(druid: druid, errors: errors)
     end
+  rescue StandardError => e # put workflow step into an error state before sending to HB
+    log_failure(druid: druid, errors: e.message)
+    Honeybadger.notify(e)
   end
 
   private

--- a/spec/jobs/technical_metadata_workflow_job_spec.rb
+++ b/spec/jobs/technical_metadata_workflow_job_spec.rb
@@ -15,25 +15,41 @@ RSpec.describe TechnicalMetadataWorkflowJob do
 
   let(:client) { instance_double(Dor::Workflow::Client, update_status: nil, update_error_status: nil) }
 
-  before do
-    allow(TechnicalMetadataGenerator).to receive(:generate_with_file_info).and_return(errors)
-    allow(Dor::Workflow::Client).to receive(:new).and_return(client)
-    job.perform(druid: druid, file_infos: file_infos)
-  end
+  context 'when no exception' do
+    before do
+      allow(TechnicalMetadataGenerator).to receive(:generate_with_file_info).and_return(errors)
+      allow(Dor::Workflow::Client).to receive(:new).and_return(client)
+      job.perform(druid: druid, file_infos: file_infos)
+    end
 
-  context 'when no errors' do
-    let(:errors) { [] }
+    context 'when no errors' do
+      let(:errors) { [] }
 
-    it('logs success') do
-      expect(client).to have_received(:update_status)
+      it('logs success') do
+        expect(client).to have_received(:update_status)
+      end
+    end
+
+    context 'when an error' do
+      let(:errors) { ['Ooops'] }
+
+      it('logs error') do
+        expect(client).to have_received(:update_error_status)
+      end
     end
   end
 
-  context 'when an error' do
-    let(:errors) { ['Ooops'] }
+  context 'when an exception occurs' do
+    before do
+      allow(Honeybadger).to receive(:notify)
+      allow(TechnicalMetadataGenerator).to receive(:generate_with_file_info).and_raise(StandardError)
+      allow(Dor::Workflow::Client).to receive(:new).and_return(client)
+      job.perform(druid: druid, file_infos: file_infos)
+    end
 
-    it('logs error') do
+    it('logs error and sets workflow step to error') do
       expect(client).to have_received(:update_error_status)
+      expect(Honeybadger).to have_received(:notify)
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #389 - put the `technical-metadata` metadata step into an error state in addition to notifying HB if there is an exception when the job is running, so that it is more clear that the process failed and is not still running

## How was this change tested? 🤨

Updated spec