### PR TITLE
Revert "Escape filepaths before sending to open3"

### DIFF
--- a/app/services/av_characterizer_service.rb
+++ b/app/services/av_characterizer_service.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'open3'
-require 'shellwords'
 
 # Characterizes an A/V file using mediainfo.
 class AvCharacterizerService
@@ -12,7 +11,7 @@ class AvCharacterizerService
   # @return [Hash, Array<Hash>] attributes, array of file part attributes.
   # @raise [AvCharacterizerService::Error]
   def characterize(filepath:)
-    output, status = Open3.capture2e('mediainfo', '-f', '--Output=JSON', Shellwords.escape(filepath))
+    output, status = Open3.capture2e('mediainfo', '-f', '--Output=JSON', filepath)
     raise Error, "Characterizing #{filepath} returned #{status.exitstatus}: #{output}" unless status.success?
 
     extract(output, filepath)

--- a/app/services/file_identifier_service.rb
+++ b/app/services/file_identifier_service.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'open3'
-require 'shellwords'
 
 # Identifies a file using Siegfried.
 class FileIdentifierService
@@ -12,7 +11,7 @@ class FileIdentifierService
   # @return [String,String|nil,nil] pronom id, mimetype of the file or nil, nil if unknown
   # @raise [FileIdentifierService::Error]
   def identify(filepath:)
-    output, err, status = Open3.capture3('sf', '-json', Shellwords.escape(filepath))
+    output, err, status = Open3.capture3('sf', '-json', filepath)
     raise Error, "Identifying #{filepath} returned #{status.exitstatus}: #{err}\n#{output}" unless status.success?
 
     pronom_id, mimetype = extract_file_types(output, filepath)

--- a/app/services/image_characterizer_service.rb
+++ b/app/services/image_characterizer_service.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'open3'
-require 'shellwords'
 
 # Characterizes an image using exiftool.
 class ImageCharacterizerService
@@ -12,9 +11,7 @@ class ImageCharacterizerService
   # @return [Hash] attributes including height and width
   # @raise [ImageCharacterizerService::Error]
   def characterize(filepath:)
-    output, err, status = Open3.capture3(
-      'exiftool', '-ImageHeight', '-ImageWidth', '-json', Shellwords.escape(filepath)
-    )
+    output, err, status = Open3.capture3('exiftool', '-ImageHeight', '-ImageWidth', '-json', filepath)
     raise Error, "Characterizing #{filepath} returned #{status.exitstatus}: #{err}\n#{output}" unless status.success?
 
     extract_attributes(output, filepath)

--- a/app/services/pdf_characterizer_service.rb
+++ b/app/services/pdf_characterizer_service.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'open3'
-require 'shellwords'
 
 # Characterizes a PDF using Poppler.
 class PdfCharacterizerService
@@ -13,7 +12,7 @@ class PdfCharacterizerService
   #   form, creator, producer
   # @raise [PdfCharacterizerService::Error]
   def characterize(filepath:)
-    output, status = Open3.capture2e('pdfinfo', Shellwords.escape(filepath))
+    output, status = Open3.capture2e('pdfinfo', filepath)
     raise Error, "Characterizing #{filepath} returned #{status.exitstatus}: #{output}" unless status.success?
 
     extract_attributes(output).merge(text: text?(filepath))
@@ -36,7 +35,7 @@ class PdfCharacterizerService
   private
 
   def text?(filepath)
-    output, status = Open3.capture2e('pdftotext', Shellwords.escape(filepath), '-')
+    output, status = Open3.capture2e('pdftotext', filepath, '-')
     raise Error, "Extracting text from #{filepath} returned #{status.exitstatus}: #{output}" unless status.success?
 
     output.present?

--- a/spec/services/av_characterizer_service_spec.rb
+++ b/spec/services/av_characterizer_service_spec.rb
@@ -262,14 +262,14 @@ RSpec.describe AvCharacterizerService do
     end
 
     context 'when file with text track is characterized' do
-      let(:characterization) { service.characterize(filepath: 'make_believe[1].xyz') }
+      let(:characterization) { service.characterize(filepath: 'make_believe.xyz') }
 
       # This output is made up and should be replaced once we have a sample file with a text track.
       let(:output) do
         <<~OUTPUT
           {
           "media": {
-          "@ref": "make_believe[1].xyz",
+          "@ref": "make_believe.xyz",
           "track": [
           {
           "@type": "General",
@@ -295,7 +295,7 @@ RSpec.describe AvCharacterizerService do
                                         [{ part_type: 'text', part_id: '2', order: 1, format: nil,
                                            audio_metadata: nil,
                                            video_metadata: nil, other_metadata: nil }]])
-        expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', 'make_believe\[1\].xyz')
+        expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', 'make_believe.xyz')
       end
     end
 

--- a/spec/services/file_identifier_service_spec.rb
+++ b/spec/services/file_identifier_service_spec.rb
@@ -119,16 +119,5 @@ RSpec.describe FileIdentifierService do
         expect(identifiers).to eq(['x-fmt/263', 'application/zip'])
       end
     end
-
-    context 'when file contains characters needing escaping' do
-      let(:identifiers) { service.identify(filepath: 'sample[1].txt') }
-      let(:output) { '{"siegfried":"1.10.0","signature":"default.sig","created":"2023-03-23T15:09:43Z","identifiers":[{"name":"pronom","details":"DROID_SignatureFile_V111.xml; container-signature-20230307.xml"}],"files":[{"filename":"sample[1].txt","filesize": 28,"modified":"2023-04-11T14:44:47-07:00","errors": "","matches": [{"ns":"pronom","id":"x-fmt/111","format":"Plain Text File","version":"","mime":"text/plain","class":"","basis":"extension match txt; text match ASCII","warning":""}]}]}' }
-      let(:status) { instance_double(Process::Status, success?: true) }
-
-      it 'returns pronom id and mimetype and receives the filename in escaped form' do
-        expect(identifiers).to eq(['x-fmt/111', 'text/plain'])
-        expect(Open3).to have_received(:capture3).with('sf', '-json', 'sample\[1\].txt')
-      end
-    end
   end
 end

--- a/spec/services/image_characterizer_service_spec.rb
+++ b/spec/services/image_characterizer_service_spec.rb
@@ -50,13 +50,13 @@ RSpec.describe ImageCharacterizerService do
   end
 
   describe '#characterize' do
-    let(:characterization) { service.characterize(filepath: 'bar[foo].png') }
+    let(:characterization) { service.characterize(filepath: 'bar.png') }
 
     context 'when file is characterized' do
       let(:output) do
         <<~OUTPUT
           [{
-            "SourceFile": "bar[foo].png",
+            "SourceFile": "bar.png",
             "ImageHeight": 694,
             "ImageWidth": 1366
           }]
@@ -66,8 +66,7 @@ RSpec.describe ImageCharacterizerService do
 
       it 'returns height and width' do
         expect(characterization).to eq(height: 694, width: 1366)
-        expect(Open3).to have_received(:capture3)
-          .with('exiftool', '-ImageHeight', '-ImageWidth', '-json', 'bar\[foo\].png')
+        expect(Open3).to have_received(:capture3).with('exiftool', '-ImageHeight', '-ImageWidth', '-json', 'bar.png')
       end
     end
 
@@ -75,7 +74,7 @@ RSpec.describe ImageCharacterizerService do
       let(:output) do
         <<~OUTPUT
           [{
-            "SourceFile": "bar[foo].png"
+            "SourceFile": "bar.png"
           }]
         OUTPUT
       end
@@ -103,7 +102,7 @@ RSpec.describe ImageCharacterizerService do
       let(:output) do
         <<~OUTPUT
           [{
-            "SourceFile": "bar[foo].png",
+            "SourceFile": "bar.png",
             "ImageHeight": 694,
             "ImageWidth": 1366
           }]
@@ -112,8 +111,7 @@ RSpec.describe ImageCharacterizerService do
 
       it 'returns height and width' do
         expect(characterization).to eq(height: 694, width: 1366)
-        expect(Open3).to have_received(:capture3)
-          .with('exiftool', '-ImageHeight', '-ImageWidth', '-json', 'bar\[foo\].png')
+        expect(Open3).to have_received(:capture3).with('exiftool', '-ImageHeight', '-ImageWidth', '-json', 'bar.png')
       end
     end
 

--- a/spec/services/pdf_characterizer_service_spec.rb
+++ b/spec/services/pdf_characterizer_service_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe PdfCharacterizerService do
   end
 
   describe '#characterize' do
-    let(:characterization) { service.characterize(filepath: 'brief[draft].pdf') }
+    let(:characterization) { service.characterize(filepath: 'brief.pdf') }
 
     context 'when file is characterized' do
       let(:output) do
@@ -97,8 +97,8 @@ RSpec.describe PdfCharacterizerService do
                                        page_size: '612 x 792 pts (letter)',
                                        pdf_version: '1.6',
                                        text: true)
-        expect(Open3).to have_received(:capture2e).with('pdfinfo', 'brief\[draft\].pdf')
-        expect(Open3).to have_received(:capture2e).with('pdftotext', 'brief\[draft\].pdf', '-')
+        expect(Open3).to have_received(:capture2e).with('pdfinfo', 'brief.pdf')
+        expect(Open3).to have_received(:capture2e).with('pdftotext', 'brief.pdf', '-')
       end
     end
 


### PR DESCRIPTION
Reverts sul-dlss/technical-metadata-service#441

We put in this patch to work around a change in behavior (regarding filenames with brackets in them) in `siegfried`, but then learned:

1. This change in behavior was a bug in the 1.10.0 version and is about to be fixed in a patch to be released soon; and
2. Using `Shellwords.escape` for all the `Open3` shell operations broke other tools' (e.g., `pdfinfo`) ability to resolve filenames with spaces in them.

So we should revert #441 and wait for the siegfried patch coming next week. This will let the ETD PDF with spaces in its filename process.