### PR TITLE
Update to latest CircleCI orbs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby-rails: sul-dlss/ruby-rails@3.2.0
+  ruby-rails: sul-dlss/ruby-rails@4.0.0
 workflows:
   build:
     jobs:
@@ -8,14 +8,8 @@ workflows:
           name: validate
       - ruby-rails/lint:
           name: lint
-          executor:
-            name: ruby-rails/ruby
-            ruby-tag: '3.2.2'
       - ruby-rails/test-rails:
           name: test
-          executor:
-            name: ruby-rails/ruby-postgres
-            ruby-tag: '3.2.2'
       - ruby-rails/docker-publish:
           context: dlss
           dockerfile: docker/app/Dockerfile


### PR DESCRIPTION
## Why was this change made? 🤔



## How was this change tested? 🤨

⚡ ⚠ If this change consumes from or writes to other services (including shared file systems), ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test) on stage as it exercises this service*** and/or test in [stage|qa] environment, in addition to specs.  ***You will need to confirm that technical metadata was correctly created for the test, as it is a background job kicked off by a common-accessioning step.***⚡


