### PR TITLE
Do not strip timezone for AV UTC time formats

### DIFF
--- a/app/services/av_characterizer_service.rb
+++ b/app/services/av_characterizer_service.rb
@@ -134,7 +134,7 @@ class AvCharacterizerService
 
     time.gsub!(/[:-]/, '') # strips : or - in date and time parts to handle cases where the date has colons or dashes
     date_format = '%Y%m%d %H%M%S%z'
-    return Time.strptime("#{time}+0000", date_format).iso8601.delete_suffix('+00:00') unless time.start_with?('UTC')
+    return Time.strptime("#{time}+0000", date_format).iso8601 unless time.start_with?('UTC')
 
     Time.strptime("#{time}+0000", "UTC #{date_format}").iso8601
   rescue ArgumentError

--- a/spec/services/av_characterizer_service_spec.rb
+++ b/spec/services/av_characterizer_service_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe AvCharacterizerService do
 
         it 'returns av_metadata and track metadata' do
           expect(characterization).to eq([{ audio_count: 1, file_extension: 'ogg', format: 'Ogg', duration: 1.002,
-                                            encoded_date: '2020-02-27T18:23:48' },
+                                            encoded_date: '2020-02-27T18:23:48+00:00' },
                                           [{ part_type: 'audio', part_id: '28470', order: nil, format: 'Vorbis',
                                              audio_metadata: { channels: '1', sampling_rate: 44_100,
                                                                stream_size: 10_020 },
@@ -144,7 +144,7 @@ RSpec.describe AvCharacterizerService do
 
         it 'returns av_metadata and track metadata' do
           expect(characterization).to eq([{ audio_count: 1, file_extension: 'ogg', format: 'Ogg', duration: 1.002,
-                                            encoded_date: '2020-02-27T18:23:48' },
+                                            encoded_date: '2020-02-27T18:23:48+00:00' },
                                           [{ part_type: 'audio', part_id: '28470', order: nil, format: 'Vorbis',
                                              audio_metadata: { channels: '1', sampling_rate: 44_100,
                                                                stream_size: 10_020 },


### PR DESCRIPTION
# Why was this change made? 🤔

Part of: https://github.com/sul-dlss/argo/issues/4041

# How was this change tested? 🤨

⚡ ⚠ If this change consumes from or writes to other services (including shared file systems), ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test) on stage as it exercises this service*** and/or test in [stage|qa] environment, in addition to specs.  ***You will need to confirm that technical metadata was correctly created for the test, as it is a background job kicked off by a common-accessioning step.***⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



