### PR TITLE
do not constrain date-time response in API

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -128,7 +128,6 @@ components:
           format: float
         encoded_date:
           type: string
-          format: date-time
     DroFile:
       description: Technical metadata for a single file
       type: object


### PR DESCRIPTION
# Why was this change made? 🤔

Some objects have invalid date/times in the AV technical metadata, and it is already like this in the database.  However, our current API constraints make the API call blow up in the response.  This is not desirable and leads to stuff like this: https://argo.stanford.edu/view/druid:bb012th8016 (see bottom of the page under `Technical Metadata` section.

