### PR TITLE
Add endpoint for auditing techMD DB contents

### DIFF
--- a/app/controllers/technical_metadata_controller.rb
+++ b/app/controllers/technical_metadata_controller.rb
@@ -6,7 +6,8 @@ require 'uri'
 class TechnicalMetadataController < ApiController
   # POST /v1/technical-metadata
   def create
-    TechnicalMetadataWorkflowJob.set(queue:).perform_later(druid: params[:druid], file_infos:,
+    TechnicalMetadataWorkflowJob.set(queue:).perform_later(druid: params[:druid],
+                                                           file_infos: file_create_infos,
                                                            force: force?)
 
     head :ok
@@ -18,14 +19,57 @@ class TechnicalMetadataController < ApiController
     head(:not_found) if @files.empty?
   end
 
+  # Given a druid (in the URL path) and a list of filename/md5 pairs (in the request body with filename URL encoded),
+  # return any differences between the expected (given) file signature list and the actual contents of technical
+  # metadata service's DB.
+  #
+  # @note This is just a read, and so should be idempotent, but we're using a POST instead of a GET, because
+  # the parameter list might exceed the traditional 2 kB limit on URL params for a GET request.
+  # @note The returned structure is a list of expected filenames that techMD does not know about but
+  # should (missing_filenames), a list of filenames for which techMD has info but shouldn't (unexpected_filenames), and
+  # a list of files where techMD and the caller each have differing metadata (mismatched_checksum_file_infos, a list of
+  # hashes with filename and md5, where the md5 is the one techMD has recorded, since the caller already knows the
+  # checksum they provided).
+  #
+  # POST /v1/technical-metadata/audit/{druid}
+  def audit_by_druid
+    techmd_dro_files = DroFile.where(druid: params[:druid])
+    return head(:not_found) if techmd_dro_files.empty?
+
+    render json: diff(techmd_dro_files:, expected_file_infos: file_audit_infos).to_json
+  end
+
   private
 
-  def file_infos
+  def diff(techmd_dro_files:, expected_file_infos:)
+    recorded_filenames = techmd_dro_files.pluck(:filename)
+    expected_filenames = expected_file_infos.pluck(:filename)
+
+    missing_filenames = expected_filenames - recorded_filenames
+    unexpected_filenames = recorded_filenames - expected_filenames
+
+    mismatched_checksum_file_infos = expected_file_infos.filter_map do |expected_file|
+      techmd_dro_files.where(filename: expected_file[:filename]).where.not(md5: expected_file[:md5]).map do |dro_file|
+        dro_file.attributes.slice('filename', 'md5')
+      end.presence # if no mismatches are found, []#presence will return nil, and filter_map will discard it
+    end.flatten
+
+    { missing_filenames:, unexpected_filenames:, mismatched_checksum_file_infos: }
+  end
+
+  def file_create_infos
     params[:files].map do |file|
       filepath = CGI.unescape(URI(file[:uri]).path)
       filename = FilepathSupport.filename_for(filepath:, basepath: params[:basepath])
       FileInfo.new(filepath:, md5: file[:md5], filename:)
     end
+  end
+
+  def file_audit_infos
+    @file_audit_infos ||=
+      params[:expected_files].map do |expected_file|
+        { filename: CGI.unescape(expected_file[:filename]), md5: expected_file[:md5] }
+      end
   end
 
   def queue

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   scope 'v1' do
     post '/technical-metadata', to: 'technical_metadata#create'
     get '/technical-metadata/druid/:druid', to: 'technical_metadata#show_by_druid'
+    post '/technical-metadata/audit/:druid', to: 'technical_metadata#audit_by_druid' # POST, since params may be > 2 kB
   end
 
   resources :home, only: [:index]

--- a/openapi.yml
+++ b/openapi.yml
@@ -84,6 +84,43 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Druid'
+  /v1/technical-metadata/audit/{druid}:
+    post:
+      tags:
+        - metadata
+      summary: Diff the technical metadata DB entries for a druid against the expected file/hash list provided to the endpoint
+      description: ''
+      operationId: technical_metadata#audit_by_druid
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FileAuditResult'
+        '404':
+          description: Druid not found
+        '401':
+          description: Unauthorized
+      parameters:
+        - name: druid
+          in: path
+          description: druid for which to audit the technical metadata
+          required: true
+          schema:
+            $ref: '#/components/schemas/Druid'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - expected_files
+              properties:
+                expected_files:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/FileAuditInfo'
 components:
   schemas:
     AudioMetadata:
@@ -194,6 +231,11 @@ components:
       type: string
       pattern: '^file:\/\/\/([^\\/]+\/)*[^\\/]+$'
       example: 'file:///foo/bar/baz/quix.jp2'
+    FileName:
+      description: filename for a file in SDR (from Cocina metadata)
+      type: string
+      pattern: '^([^\\/]+\/)*[^\\/]+$'
+      example: 'foo/bar/baz/quix.jp2'
     FileInfo:
       description: Information about a file.
       type: object
@@ -205,6 +247,36 @@ components:
       required:
         - uri
         - md5
+    FileAuditInfo:
+      description: Information about a file in SDR for which we expect technical metadata to exist.
+      type: object
+      properties:
+        filename:
+          $ref: '#/components/schemas/FileName'
+        md5:
+          type: string
+      required:
+        - filename
+        - md5
+    FileAuditResult:
+      description: Information about detected differences between expected technical metadata entries and actual technical metadata entries
+      type: object
+      properties:
+        missing_filenames:
+          type: array
+          items:
+            $ref:
+              '#/components/schemas/FileName'
+        unexpected_filenames:
+          type: array
+          items:
+            $ref:
+              '#/components/schemas/FileName'
+        mismatched_checksum_file_infos:
+          type: array
+          items:
+            $ref:
+              '#/components/schemas/FileAuditInfo'
     ImageMetadata:
       description: Image-specific technical metadata
       type: object

--- a/spec/requests/audit_technical_metadata_spec.rb
+++ b/spec/requests/audit_technical_metadata_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Request audit technical metadata' do
+  let(:druid) { 'druid:bc123df4567' }
+
+  let(:file_info_0001) { { filename: '0001.html', md5: '1711cb9f08a0504e1035d198d08edda9' } } # rubocop:disable Naming/VariableNumber more consistent with the other var names, and not actually a numbered var anyway
+  let(:file_info_bar) { { filename: 'bar.txt', md5: 'c157a79031e1c40f85931829bc5fc552' } }
+  let(:file_info_foo) { { filename: 'dir/foo.txt', md5: '4be1a9f251bb9c7dd3343abb94e6e9e1' } }
+  let(:file_info_one_space) { { filename: 'one%20space.txt', md5: 'bec8c64f3ade34fe1aa1914c075ba8e9' } }
+  let(:file_info_two_spaces) { { filename: 'two%20%20spaces.txt', md5: '2c744dffd279d7e9e0910ce594eb4f4f' } }
+  let(:files_param) { [file_info_0001, file_info_bar, file_info_foo, file_info_one_space] }
+  let(:data) { { expected_files: files_param } }
+
+  let(:payload) { { sub: 'sdr' } }
+  let(:hmac_secret) { Settings.hmac_secret }
+  let(:jwt) { JWT.encode(payload, hmac_secret, 'HS256') }
+  let(:headers) { { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{jwt}" } }
+
+  context 'when techMD DB has no file info for the druid' do
+    it 'returns 404' do
+      post("/v1/technical-metadata/audit/#{druid}", params: data.to_json, headers:)
+
+      expect(response).to be_not_found
+    end
+  end
+
+  context 'when techMD DB has file info for the druid' do
+    context 'when techMD DB has info that matches the expected file info' do
+      before do
+        DroFile.create(druid:, filename: '0001.html', md5: '1711cb9f08a0504e1035d198d08edda9', bytes: 11)
+        DroFile.create(druid:, filename: 'bar.txt', md5: 'c157a79031e1c40f85931829bc5fc552', bytes: 11)
+        DroFile.create(druid:, filename: 'dir/foo.txt', md5: '4be1a9f251bb9c7dd3343abb94e6e9e1', bytes: 11)
+        DroFile.create(druid:, filename: 'one space.txt', md5: 'bec8c64f3ade34fe1aa1914c075ba8e9', bytes: 11)
+      end
+
+      it 'reports no differences' do
+        post("/v1/technical-metadata/audit/#{druid}", params: data.to_json, headers:)
+
+        expect(response).to be_ok
+        expect(response.parsed_body).to eq({ 'missing_filenames' => [],
+                                             'unexpected_filenames' => [],
+                                             'mismatched_checksum_file_infos' => [] })
+      end
+    end
+
+    context 'when techMD DB is missing file entries contained in the expected file list' do
+      let(:files_param) { [file_info_0001, file_info_bar, file_info_foo, file_info_one_space, file_info_two_spaces] }
+
+      before do
+        DroFile.create(druid:, filename: '0001.html', md5: '1711cb9f08a0504e1035d198d08edda9', bytes: 11)
+        DroFile.create(druid:, filename: 'bar.txt', md5: 'c157a79031e1c40f85931829bc5fc552', bytes: 11)
+        DroFile.create(druid:, filename: 'one space.txt', md5: 'bec8c64f3ade34fe1aa1914c075ba8e9', bytes: 11)
+      end
+
+      it 'reports the missing files' do
+        post("/v1/technical-metadata/audit/#{druid}", params: data.to_json, headers:)
+
+        expect(response).to be_ok
+        expect(response.parsed_body['missing_filenames']).to contain_exactly('dir/foo.txt', 'two  spaces.txt')
+        expect(response.parsed_body['unexpected_filenames']).to eq([])
+        expect(response.parsed_body['mismatched_checksum_file_infos']).to eq([])
+      end
+    end
+
+    context 'when techMD DB has entries for files not contained in the expected file list' do
+      let(:files_param) { [file_info_0001, file_info_bar, file_info_foo] }
+
+      before do
+        DroFile.create(druid:, filename: '0001.html', md5: '1711cb9f08a0504e1035d198d08edda9', bytes: 11)
+        DroFile.create(druid:, filename: 'bar.txt', md5: 'c157a79031e1c40f85931829bc5fc552', bytes: 11)
+        DroFile.create(druid:, filename: 'dir/foo.txt', md5: '4be1a9f251bb9c7dd3343abb94e6e9e1', bytes: 11)
+        DroFile.create(druid:, filename: 'one space.txt', md5: 'bec8c64f3ade34fe1aa1914c075ba8e9', bytes: 11)
+        DroFile.create(druid:, filename: 'two  spaces.txt', md5: '2c744dffd279d7e9e0910ce594eb4f4f', bytes: 11)
+      end
+
+      it 'reports the unexpected files' do
+        post("/v1/technical-metadata/audit/#{druid}", params: data.to_json, headers:)
+
+        expect(response).to be_ok
+        expect(response.parsed_body['missing_filenames']).to eq([])
+        expect(response.parsed_body['unexpected_filenames']).to contain_exactly('one space.txt', 'two  spaces.txt')
+        expect(response.parsed_body['mismatched_checksum_file_infos']).to eq([])
+      end
+    end
+
+    context 'when techMD DB has the same files as the expected file list, but not all of the hashes match' do
+      before do
+        DroFile.create(druid:, filename: '0001.html', md5: '1711cb9f08a0504e1035d198d08edda9', bytes: 11)
+        DroFile.create(druid:, filename: 'bar.txt', md5: 'c157a79031e1c40f85931829bc5fc552', bytes: 11)
+        DroFile.create(druid:, filename: 'dir/foo.txt', md5: '4be1a9f251bb9c7dd3343abb94e6e9e1', bytes: 11)
+        DroFile.create(druid:, filename: 'one space.txt', md5: '4baac6efc837285acdd8186f162ead4f', bytes: 11)
+      end
+
+      it 'reports the files with mismatched checksums' do
+        post("/v1/technical-metadata/audit/#{druid}", params: data.to_json, headers:)
+
+        expect(response).to be_ok
+        expect(response.parsed_body['missing_filenames']).to eq([])
+        expect(response.parsed_body['unexpected_filenames']).to eq([])
+        expect(response.parsed_body['mismatched_checksum_file_infos']).to contain_exactly({ 'filename' => 'one space.txt', # rubocop:disable Layout/LineLength
+                                                                                            'md5' => '4baac6efc837285acdd8186f162ead4f' }) # rubocop:disable Layout/LineLength
+      end
+    end
+
+    context 'when techMD DB has the same file info for a different druid' do
+      let(:druid) { 'druid:gh123jk4567' }
+
+      before do
+        DroFile.create(druid:, filename: '0001.html', md5: '1711cb9f08a0504e1035d198d08edda9', bytes: 11)
+        DroFile.create(druid:, filename: 'bar.txt', md5: 'c157a79031e1c40f85931829bc5fc552', bytes: 11)
+        DroFile.create(druid:, filename: 'dir/foo.txt', md5: '4be1a9f251bb9c7dd3343abb94e6e9e1', bytes: 11)
+        DroFile.create(druid:, filename: 'one space.txt', md5: '4baac6efc837285acdd8186f162ead4f', bytes: 11)
+      end
+
+      it 'reports the expected files as missing (since they are for that druid)' do
+        post('/v1/technical-metadata/audit/druid:bc123df4567', params: data.to_json, headers:)
+
+        expect(response).to be_not_found
+      end
+    end
+  end
+
+  context 'when unauthorized' do
+    let(:hmac_secret) { 'c0mpromised$ecretThatWeAlreadyRotat3d' }
+
+    it 'returns 401' do
+      post("/v1/technical-metadata/audit/#{druid}", params: data.to_json, headers:)
+
+      expect(response).to be_unauthorized
+    end
+  end
+end


### PR DESCRIPTION
# Why was this change made? 🤔

part of https://github.com/sul-dlss/technical-metadata-service/issues/515

The ticket suggested using the same input structure as the create endpoint.  But I realized after implementing it that way and looking at some example Cocina and some example techMD service DB entries on stage,  that might not be the most convenient thing for the caller (since both the cocina and techMD DB store a filename, not a full URI).  In case that later realization was wrong, I left that change as a separate commit, so that it's easy to back out of.  As such, I think it'd be fine to squash the commits if this is merged as-is.

# How was this change tested? 🤨

unit tests.  will test in stage as part of implementing the second part of the ticket ("Add an auditing report to DSA").

⚡ ⚠ If this change consumes from or writes to other services (including shared file systems), ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test) on stage as it exercises this service*** and/or test in [stage|qa] environment, in addition to specs.  ***You will need to confirm that technical metadata was correctly created for the test, as it is a background job kicked off by a common-accessioning step.***⚡



# Does your change introduce accessibility violations? 🩺

N/A, just adding a REST endpoint

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



