### PR TITLE
Update to debian based docker images for openapi support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - db
       - workers
   workers:
+    platform: linux/amd64 # Required for running on Apple Silicon
     build:
       context: .
       dockerfile: docker/workers/Dockerfile

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,14 +1,8 @@
-# This Dockerfile is optimized for running in development. That means it trades
-# build speed for size. If we were using this for production, we might instead
-# optimize for a smaller size at the cost of a slower build.
-FROM ruby:3.2.2-alpine
-
-# postgresql-client is required for invoke.sh
-RUN apk add --update --no-cache  \
-  build-base \
-  postgresql-dev \
-  postgresql-client \
-  tzdata
+FROM ruby:3.3.2-bookworm
+    
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+        postgresql-client postgresql-contrib libpq-dev
 
 # Get latest bundler
 RUN gem install bundler

--- a/docker/workers/Dockerfile
+++ b/docker/workers/Dockerfile
@@ -1,10 +1,6 @@
-# This Dockerfile is optimized for running in development. That means it trades
-# build speed for size. If we were using this for production, we might instead
-# optimize for a smaller size at the cost of a slower build.
-#
 # NOTE: This uses a Debian-based image rather than an Alpine-based image so that
 #       we can install Debian packages. In particular: siegfried.
-FROM ruby:3.2.2-buster
+FROM ruby:3.3.2-bookworm
 
 # Two-pass package update: first install everything except siegfried, which is
 # installed via add-apt-repository, a tool that isn't installed until
@@ -13,11 +9,11 @@ FROM ruby:3.2.2-buster
 # * postgresql-client is required for invoke.sh
 # * siegfried, exiftool, poppler, and mediainfo are needed for file characterization
 RUN apt-get update -qq && \
-    apt-get install -y build-essential postgresql-client exiftool poppler-utils mediainfo software-properties-common && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 20F802FE798E6857 && \
-    add-apt-repository "deb https://www.itforarchivists.com/ buster main" && \
-    apt-get update -qq && \
-    apt-get install -y siegfried
+    apt-get install -y build-essential postgresql-client exiftool poppler-utils mediainfo software-properties-common
+
+RUN curl -sL "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x20F802FE798E6857" | gpg --dearmor | tee /usr/share/keyrings/siegfried-archive-keyring.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/siegfried-archive-keyring.gpg] https://www.itforarchivists.com/ buster main" | tee -a /etc/apt/sources.list.d/siegfried.list
+RUN apt-get update && apt-get install siegfried
 
 # Get latest bundler
 RUN gem install bundler


### PR DESCRIPTION
# Why was this change made? 🤔

Required to maintain compatibility with openapi_parser.

# How was this change tested? 🤨

⚡ ⚠ If this change consumes from or writes to other services (including shared file systems), ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test) on stage as it exercises this service*** and/or test in [stage|qa] environment, in addition to specs.  ***You will need to confirm that technical metadata was correctly created for the test, as it is a background job kicked off by a common-accessioning step.***⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



