### PR TITLE
Unpin erblint and update it so techmd uses the latest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'moab-versioning', '~> 6.0'
 
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
-  gem 'erb_lint', '~> 0.5.0', require: false
+  gem 'erb_lint', require: false
   gem 'rspec_junit_formatter'
   gem 'rspec-rails'
   gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,12 +136,12 @@ GEM
       zeitwerk (~> 2.1)
     druid-tools (3.0.0)
     ed25519 (1.3.0)
-    erb_lint (0.5.0)
+    erb_lint (0.6.0)
       activesupport
       better_html (>= 2.0.1)
       parser (>= 2.7.1.4)
       rainbow
-      rubocop
+      rubocop (>= 1)
       smart_properties
     erubi (1.13.0)
     faraday (2.10.1)
@@ -222,8 +222,8 @@ GEM
       nokogiri (~> 1.5)
     okcomputer (1.18.5)
     openapi_parser (2.1.0)
-    parallel (1.25.1)
-    parser (3.3.4.0)
+    parallel (1.26.1)
+    parser (3.3.4.2)
       ast (~> 2.4.1)
       racc
     pg (1.5.7)
@@ -307,7 +307,7 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.31.3)
+    rubocop-ast (1.32.0)
       parser (>= 3.3.1.0)
     rubocop-capybara (2.21.0)
       rubocop (~> 1.41)
@@ -379,7 +379,7 @@ DEPENDENCIES
   config
   dlss-capistrano
   dor-workflow-client (~> 7.0)
-  erb_lint (~> 0.5.0)
+  erb_lint
   honeybadger
   importmap-rails (~> 1.0)
   jbuilder


### PR DESCRIPTION
# Why was this change made?

This commit is related to a lingering prod board card

# How was this change tested?

CI
