### PR TITLE
add volume detection to media tech metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,10 @@ bundle exec rake generate_token
 
 Hit the technical-metadata-service's HTTP API:
 
+Substitute the token above:
+
 ```shell
-$ curl -i H "Authorization: Bearer #{TOKEN}" -H 'Content-Type: application/json' --data '{"druid":"druid:bc123df4567","files":["file:///app/README.md","file:///app/openapi.yml"]}' http://localhost:3000/v1/technical-metadata
+$ curl -i -H "Authorization: Bearer {TOKEN}" -H 'Content-Type: application/json' --data '{"druid":"druid:bc123df4567","files":[{"uri":"file:///app/openapi.yml", "md5": "123"},{"uri":"file:///app/README.MD", "md5":"456"}], "basepath": "//app"}' http://localhost:3000/v1/technical-metadata
 ```
 
 Verify that technical metadata was created:
@@ -186,7 +188,7 @@ Verify that technical metadata was created:
 ```shell
 $ docker compose exec app rails c
 > DroFile.pluck(:druid, :filename, :mimetype, :filetype)
-# should look like: [["druid:bc123df4567", "openapi.yml", "text/plain", "x-fmt/111"], ["druid:bc123df4567", "README.md", "text/markdown", "fmt/1149"]]
+# should look like: [["druid:bc123df4567", "openapi.yml", "text/plain", "fmt/818"], ["druid:bc123df4567", "README.md", "text/markdown", "fmt/1149"]]
 ```
 
 And that the object's workflow was updated:
@@ -194,7 +196,7 @@ And that the object's workflow was updated:
 ```shell
 $ rails c
 > client = Dor::Workflow::Client.new(url: 'http://localhost:3001')
-> client.workflow_status({druid: 'druid:bc123df4567', workflow: 'accessionWF', process: 'technical-metadata'})
+> client.workflow_status(druid: 'druid:bc123df4567', workflow: 'accessionWF', process: 'technical-metadata')
 # should be "completed"
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Success
 
 This happens synchronously and will not update the workflow service.
 
-To generate for an item from a Moab (from preservation storage):
+To generate for an item from a Moab (from preservation storage).  Setting to the second parameter to "true" will force the generation of new technical-metadata even if it already exists.
 
 ```shell
-$ bundler exec rake techmd:generate_for_moab['druid:bc123df4567', 'true']
+$ bundler exec rake techmd:generate_for_moab['druid:bc123df4567','true']
 Queued
 ```
 
@@ -213,6 +213,30 @@ Then you can run
 bin/dev
 ```
 This starts css/js bundling and the development server
+
+### Generating local technical metadata locally
+
+If you have a file on your laptop you want to test quickly to see if generation is as expected, you can do this on the rails console.
+
+```ruby
+rails c
+
+druid = 'druid:ab123bc4567'
+basepath = '//some/local/laptop/path'
+files = [{"uri":"file:///some/local/laptop/path/nc889qn3957_sl.mp4", "md5": "012"}]
+params = {druid:, files:, basepath:}
+file_infos = params[:files].map do |file|
+    filepath = CGI.unescape(URI(file[:uri]).path)
+    filename = FilepathSupport.filename_for(filepath:, basepath: params[:basepath])
+    FileInfo.new(filepath:, md5: file[:md5], filename:)
+end
+errors = TechnicalMetadataGenerator.generate_with_file_info(druid:, file_infos:, force: true)
+
+puts errors
+
+pp DroFile.where(druid:)
+DroFile.where(druid:).each {|file| pp file.dro_file_parts};nil
+```
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ To install on OS X:
 brew install mediainfo
 ```
 
+### FFMpeg
+[FFmpeg](https://github.com/FFmpeg/FFmpeg) is used for audio analysis of A/V files.
+
+To install on OS X:
+```
+brew install ffmpeg
+```
+
 ## Testing
 
 ### CI build
@@ -132,6 +140,11 @@ Spin up the database using docker-compose:
 
 ```shell
 $ docker compose up db # use -d to run in background
+```
+
+```shell
+$ rake db:setup # setup the databases (first time only)
+$ rake db:migrate # ensure up to date (after first setup)
 ```
 
 Run the linters and the test suite:

--- a/app/services/av_characterizer_service.rb
+++ b/app/services/av_characterizer_service.rb
@@ -143,7 +143,7 @@ class AvCharacterizerService
 
   # adapted from https://github.com/dnoneill/avpd/blob/a80193523558f9dcdc576ad6b9b3a76669ad2d43/app/helpers/av_helper.rb#L67
   def compute_volume_levels(filepath)
-    # examine the audio tracks to see to extract mean and max volume levels
+    # examine the audio tracks to extract mean and max volume levels
     command = "ffmpeg -i #{filepath.shellescape} -af 'volumedetect' -vn -sn -dn -f null /dev/null"
     output, status = Open3.capture2e(command)
 
@@ -154,6 +154,9 @@ class AvCharacterizerService
       mean_volume: ff_mpeg_content_parse(split_output.grep(/mean_volume/)[0]) }
   end
 
+  # parse the volume level from the ffmpeg output, looks something like this:
+  #        [Parsed_volumedetect_0 @ 0x6000012f00b0] mean_volume: -24.2 dB
+  #        [Parsed_volumedetect_0 @ 0x6000012f00b0] max_volume: -4.7 dB
   def ff_mpeg_content_parse(content)
     return nil if content.blank?
 

--- a/app/services/av_characterizer_service.rb
+++ b/app/services/av_characterizer_service.rb
@@ -42,7 +42,7 @@ class AvCharacterizerService
       when 'General'
         av_metadata = extract_general(track)
       when 'Audio'
-        tracks << extract_audio(track)
+        tracks << extract_audio(track, filepath)
       when 'Video'
         tracks << extract_video(track)
       when 'Other'
@@ -73,7 +73,7 @@ class AvCharacterizerService
     end
   end
 
-  def extract_audio(track)
+  def extract_audio(track, filepath)
     part = extract_part(track, 'audio')
     part[:audio_metadata] = {}.tap do |metadata|
       metadata[:format_profile] = track['Format_Profile'] if track['Format_Profile'].present?
@@ -82,6 +82,7 @@ class AvCharacterizerService
       metadata[:sampling_rate] = track['SamplingRate'].to_i if track['SamplingRate'].present?
       metadata[:bit_depth] = track['BitDepth'].to_i if track['BitDepth'].present?
       metadata[:stream_size] = track['StreamSize'].to_i if track['StreamSize'].present?
+      metadata[:is_silent] = silent?(filepath)
     end
     part
   end
@@ -125,6 +126,36 @@ class AvCharacterizerService
       video_metadata: nil,
       other_metadata: nil
     }
+  end
+
+  def audio_tracks?(filepath)
+    command = "ffprobe -i #{filepath.shellescape} -show_streams -select_streams a -loglevel error"
+    output, status = Open3.capture2e(command)
+
+    raise Error, "Getting ffprobe track info returned #{status.exitstatus}: #{output}" unless status.success?
+
+    output.present?
+  end
+
+  # adapted from https://github.com/dnoneill/avpd/blob/a80193523558f9dcdc576ad6b9b3a76669ad2d43/app/helpers/av_helper.rb#L67
+  def silent?(filepath)
+    # first check to see if any audio tracks even exist, if not, return true
+    return true unless audio_tracks?(filepath)
+
+    # next examine the audio tracks to see if they are silent using volume detection
+    command = "ffmpeg -i #{filepath.shellescape} -af 'volumedetect' -vn -sn -dn -f null /dev/null"
+    output, status = Open3.capture2e(command)
+
+    raise Error, "Getting ffmpeg volume detection returned #{status.exitstatus}: #{output}" unless status.success?
+
+    split_output = output.split("\n")
+    max_volume = ff_mpeg_content_parse(split_output.grep(/max_volume/)[0])
+    mean_volume = ff_mpeg_content_parse(split_output.grep(/mean_volume/)[0])
+    mean_volume < -40 && max_volume < -30
+  end
+
+  def ff_mpeg_content_parse(content)
+    content.split(':')[-1].gsub!(/[^0-9\-.]/, '').strip.to_f
   end
 
   # @param [String,nil] time a date with format like 'UTC 2020-02-27 06:06:04' or nil if blank or unparseable.

--- a/app/services/av_characterizer_service.rb
+++ b/app/services/av_characterizer_service.rb
@@ -2,7 +2,7 @@
 
 require 'open3'
 
-# Characterizes an A/V file using mediainfo.
+# Characterizes an A/V file using mediainfo and ffmpeg.
 class AvCharacterizerService
   class Error < CharacterizationError
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2020_03_04_012620) do
+ActiveRecord::Schema[7.2].define(version: 2020_03_04_012620) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -140,9 +140,11 @@ components:
         stream_size:
           type: integer
         mean_volume:
-          type: integer
+          type: number
+          format: float
         max_volume:
-          type: integer
+          type: number
+          format: float
     AvMetadata:
       description: Audio/visual-specific technical metadata
       type: object

--- a/openapi.yml
+++ b/openapi.yml
@@ -139,8 +139,10 @@ components:
           type: integer
         stream_size:
           type: integer
-        is_silent:
-          type: boolean
+        mean_volume:
+          type: integer
+        max_volume:
+          type: integer
     AvMetadata:
       description: Audio/visual-specific technical metadata
       type: object

--- a/openapi.yml
+++ b/openapi.yml
@@ -139,6 +139,8 @@ components:
           type: integer
         stream_size:
           type: integer
+        is_silent:
+          type: boolean
     AvMetadata:
       description: Audio/visual-specific technical metadata
       type: object

--- a/spec/services/av_characterizer_service_spec.rb
+++ b/spec/services/av_characterizer_service_spec.rb
@@ -4,9 +4,27 @@ require 'open3'
 
 RSpec.describe AvCharacterizerService do
   let(:service) { described_class.new }
+  let(:status) { instance_double(Process::Status, success?: true) }
+  let(:volume_detect) do
+    <<~VOLUME
+      Lots of stuff here
+      [Parsed_volumedetect_0 @ 0x6000012f00b0] n_samples: 28525216
+      [Parsed_volumedetect_0 @ 0x6000012f00b0] mean_volume: -24.2 dB
+      [Parsed_volumedetect_0 @ 0x6000012f00b0] max_volume: -4.7 dB
+      More unused stuff here
+    VOLUME
+  end
+  let(:track_info) { 'track info' }
+  let(:ffmpeg_command) { "ffmpeg -i #{filepath} -af 'volumedetect' -vn -sn -dn -f null /dev/null" }
+  let(:ffprobe_command) { "ffprobe -i #{filepath} -show_streams -select_streams a -loglevel error" }
 
   before do
-    allow(Open3).to receive(:capture2e).and_return([output, status])
+    allow(Open3).to receive(:capture2e).with('mediainfo', '-f', '--Output=JSON', /.*/).and_return([output, status])
+    allow(Open3).to receive(:capture2e).with('mediainfo --Version').and_return([output, status])
+    allow(Open3).to receive(:capture2e).with(%r{ffmpeg -i .* -af 'volumedetect' -vn -sn -dn -f null /dev/null})
+                                       .and_return([volume_detect, status])
+    allow(Open3).to receive(:capture2e).with(/ffprobe -i .* -show_streams -select_streams a -loglevel error/)
+                                       .and_return([track_info, status])
   end
 
   describe '#version' do
@@ -19,8 +37,6 @@ RSpec.describe AvCharacterizerService do
           MediaInfoLib - v19.09
         OUTPUT
       end
-
-      let(:status) { instance_double(Process::Status, success?: true) }
 
       it 'returns version' do
         expect(version).to eq('v19.09')
@@ -37,7 +53,6 @@ RSpec.describe AvCharacterizerService do
     end
 
     context 'when mediainfo produces unexpected results' do
-      let(:status) { instance_double(Process::Status, success?: true) }
       let(:output) { 'What??' }
 
       it 'raises' do
@@ -47,14 +62,15 @@ RSpec.describe AvCharacterizerService do
   end
 
   describe '#characterize' do
-    let(:characterization) { service.characterize(filepath: 'noam.ogg') }
+    let(:filepath) { 'noam.ogg' }
+    let(:characterization) { service.characterize(filepath:) }
 
     context 'when audio file is characterized' do
       let(:output) do
         <<~OUTPUT
           {
           "media": {
-          "@ref": "noam.ogg",
+          "@ref": "#{filepath}",
           "track": [
           {
           "@type": "General",
@@ -95,8 +111,6 @@ RSpec.describe AvCharacterizerService do
         OUTPUT
       end
 
-      let(:status) { instance_double(Process::Status, success?: true) }
-
       context 'when date is UTC' do
         let(:encoded_date) { '"UTC 2020-02-27 18:23:48"' }
 
@@ -104,10 +118,52 @@ RSpec.describe AvCharacterizerService do
           expect(characterization).to eq([{ audio_count: 1, file_extension: 'ogg', format: 'Ogg', duration: 1.002,
                                             encoded_date: '2020-02-27T18:23:48+00:00' },
                                           [{ part_type: 'audio', part_id: '28470', order: nil, format: 'Vorbis',
-                                             audio_metadata: { channels: '1', sampling_rate: 44_100,
+                                             audio_metadata: { channels: '1', sampling_rate: 44_100, is_silent: false,
                                                                stream_size: 10_020 },
                                              video_metadata: nil, other_metadata: nil }]])
-          expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', 'noam.ogg')
+          expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', filepath)
+          expect(Open3).to have_received(:capture2e).with(ffprobe_command)
+          expect(Open3).to have_received(:capture2e).with(ffmpeg_command)
+        end
+
+        context 'when no audio track is detected by ffprobe' do
+          let(:track_info) { '' }
+
+          it 'indicates the audio is silent and does not run ffmpeg command' do
+            expect(characterization).to eq([{ audio_count: 1, file_extension: 'ogg', format: 'Ogg', duration: 1.002,
+                                              encoded_date: '2020-02-27T18:23:48+00:00' },
+                                            [{ part_type: 'audio', part_id: '28470', order: nil, format: 'Vorbis',
+                                               audio_metadata: { channels: '1', sampling_rate: 44_100, is_silent: true,
+                                                                 stream_size: 10_020 },
+                                               video_metadata: nil, other_metadata: nil }]])
+            expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', filepath)
+            expect(Open3).to have_received(:capture2e).with(ffprobe_command)
+            expect(Open3).not_to have_received(:capture2e).with(ffmpeg_command)
+          end
+        end
+
+        context 'when an audio track is detected by ffprobe but the volume levels are low' do
+          let(:volume_detect) do
+            <<~VOLUME
+              Lots of stuff here
+              [Parsed_volumedetect_0 @ 0x6000012f00b0] n_samples: 28525216
+              [Parsed_volumedetect_0 @ 0x6000012f00b0] mean_volume: -45.2 dB
+              [Parsed_volumedetect_0 @ 0x6000012f00b0] max_volume: -31.7 dB
+              More unused stuff here
+            VOLUME
+          end
+
+          it 'indicates the audio is silent' do
+            expect(characterization).to eq([{ audio_count: 1, file_extension: 'ogg', format: 'Ogg', duration: 1.002,
+                                              encoded_date: '2020-02-27T18:23:48+00:00' },
+                                            [{ part_type: 'audio', part_id: '28470', order: nil, format: 'Vorbis',
+                                               audio_metadata: { channels: '1', sampling_rate: 44_100, is_silent: true,
+                                                                 stream_size: 10_020 },
+                                               video_metadata: nil, other_metadata: nil }]])
+            expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', filepath)
+            expect(Open3).to have_received(:capture2e).with(ffprobe_command)
+            expect(Open3).to have_received(:capture2e).with(ffmpeg_command)
+          end
         end
       end
 
@@ -118,10 +174,12 @@ RSpec.describe AvCharacterizerService do
           expect(characterization).to eq([{ audio_count: 1, file_extension: 'ogg', format: 'Ogg', duration: 1.002,
                                             encoded_date: '2020-02-27T18:23:48+00:00' },
                                           [{ part_type: 'audio', part_id: '28470', order: nil, format: 'Vorbis',
-                                             audio_metadata: { channels: '1', sampling_rate: 44_100,
+                                             audio_metadata: { channels: '1', sampling_rate: 44_100, is_silent: false,
                                                                stream_size: 10_020 },
                                              video_metadata: nil, other_metadata: nil }]])
-          expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', 'noam.ogg')
+          expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', filepath)
+          expect(Open3).to have_received(:capture2e).with(ffprobe_command)
+          expect(Open3).to have_received(:capture2e).with(ffmpeg_command)
         end
       end
 
@@ -132,10 +190,12 @@ RSpec.describe AvCharacterizerService do
           expect(characterization).to eq([{ audio_count: 1, file_extension: 'ogg', format: 'Ogg', duration: 1.002,
                                             encoded_date: '2020-02-27T18:23:48+00:00' },
                                           [{ part_type: 'audio', part_id: '28470', order: nil, format: 'Vorbis',
-                                             audio_metadata: { channels: '1', sampling_rate: 44_100,
+                                             audio_metadata: { channels: '1', sampling_rate: 44_100, is_silent: false,
                                                                stream_size: 10_020 },
                                              video_metadata: nil, other_metadata: nil }]])
-          expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', 'noam.ogg')
+          expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', filepath)
+          expect(Open3).to have_received(:capture2e).with(ffprobe_command)
+          expect(Open3).to have_received(:capture2e).with(ffmpeg_command)
         end
       end
 
@@ -146,10 +206,12 @@ RSpec.describe AvCharacterizerService do
           expect(characterization).to eq([{ audio_count: 1, file_extension: 'ogg', format: 'Ogg', duration: 1.002,
                                             encoded_date: '2020-02-27T18:23:48+00:00' },
                                           [{ part_type: 'audio', part_id: '28470', order: nil, format: 'Vorbis',
-                                             audio_metadata: { channels: '1', sampling_rate: 44_100,
+                                             audio_metadata: { channels: '1', sampling_rate: 44_100, is_silent: false,
                                                                stream_size: 10_020 },
                                              video_metadata: nil, other_metadata: nil }]])
-          expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', 'noam.ogg')
+          expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', filepath)
+          expect(Open3).to have_received(:capture2e).with(ffprobe_command)
+          expect(Open3).to have_received(:capture2e).with(ffmpeg_command)
         end
       end
 
@@ -159,22 +221,25 @@ RSpec.describe AvCharacterizerService do
         it 'returns av_metadata and track metadata' do
           expect(characterization).to eq([{ audio_count: 1, file_extension: 'ogg', format: 'Ogg', duration: 1.002 },
                                           [{ part_type: 'audio', part_id: '28470', order: nil, format: 'Vorbis',
-                                             audio_metadata: { channels: '1', sampling_rate: 44_100,
+                                             audio_metadata: { channels: '1', sampling_rate: 44_100, is_silent: false,
                                                                stream_size: 10_020 },
                                              video_metadata: nil, other_metadata: nil }]])
-          expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', 'noam.ogg')
+          expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', filepath)
+          expect(Open3).to have_received(:capture2e).with(ffprobe_command)
+          expect(Open3).to have_received(:capture2e).with(ffmpeg_command)
         end
       end
     end
 
     context 'when video file is characterized' do
-      let(:characterization) { service.characterize(filepath: 'max.webm') }
+      let(:filepath) { 'max.webm' }
+      let(:characterization) { service.characterize(filepath:) }
 
       let(:output) do
         <<~OUTPUT
           {
           "media": {
-          "@ref": "max.webm",
+          "@ref": "#{filepath}",
           "track": [
           {
           "@type": "General",
@@ -242,8 +307,6 @@ RSpec.describe AvCharacterizerService do
         OUTPUT
       end
 
-      let(:status) { instance_double(Process::Status, success?: true) }
-
       it 'returns av_metadata and track metadata' do
         expect(characterization).to eq([{ video_count: 1, audio_count: 1, file_extension: 'webm', format: 'WebM',
                                           duration: 33.234, frame_rate: 29.97 },
@@ -254,15 +317,18 @@ RSpec.describe AvCharacterizerService do
                                                              frame_rate: 29.97, standard: 'NTSC' },
                                            other_metadata: nil },
                                          { part_type: 'audio', part_id: '2', order: 1, format: 'Opus',
-                                           audio_metadata: { codec_id: 'A_OPUS', channels: '2', sampling_rate: 48_000,
-                                                             bit_depth: 32 },
+                                           audio_metadata: { codec_id: 'A_OPUS', is_silent: false, channels: '2',
+                                                             sampling_rate: 48_000, bit_depth: 32 },
                                            video_metadata: nil, other_metadata: nil }]])
-        expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', 'max.webm')
+        expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', filepath)
+        expect(Open3).to have_received(:capture2e).with(ffprobe_command)
+        expect(Open3).to have_received(:capture2e).with(ffmpeg_command)
       end
     end
 
     context 'when file with text track is characterized' do
-      let(:characterization) { service.characterize(filepath: 'make_believe.xyz') }
+      let(:filepath) { 'make_believe.xyz' }
+      let(:characterization) { service.characterize(filepath:) }
 
       # This output is made up and should be replaced once we have a sample file with a text track.
       let(:output) do
@@ -288,19 +354,17 @@ RSpec.describe AvCharacterizerService do
         OUTPUT
       end
 
-      let(:status) { instance_double(Process::Status, success?: true) }
-
       it 'returns av_metadata and track metadata' do
         expect(characterization).to eq([{ file_extension: 'xyz', format: 'XYZ' },
                                         [{ part_type: 'text', part_id: '2', order: 1, format: nil,
                                            audio_metadata: nil,
                                            video_metadata: nil, other_metadata: nil }]])
-        expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', 'make_believe.xyz')
+        expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', filepath)
       end
     end
 
     context 'when file with other track is characterized' do
-      let(:characterization) { service.characterize(filepath: 'make_believe.xyz') }
+      let(:characterization) { service.characterize(filepath:) }
 
       let(:title) { 'Dr. Strangelove or: How I Learned to Stop Worrying and Love the Bomb' }
 
@@ -329,15 +393,13 @@ RSpec.describe AvCharacterizerService do
         OUTPUT
       end
 
-      let(:status) { instance_double(Process::Status, success?: true) }
-
       it 'returns av_metadata and track metadata' do
         expect(characterization).to eq([{ file_extension: 'xyz', format: 'XYZ' },
                                         [{ part_type: 'other', part_id: '2', order: 1, format: nil,
                                            audio_metadata: nil,
                                            video_metadata: nil,
                                            other_metadata: { title: } }]])
-        expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', 'make_believe.xyz')
+        expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', filepath)
       end
     end
 

--- a/spec/services/av_characterizer_service_spec.rb
+++ b/spec/services/av_characterizer_service_spec.rb
@@ -118,7 +118,8 @@ RSpec.describe AvCharacterizerService do
           expect(characterization).to eq([{ audio_count: 1, file_extension: 'ogg', format: 'Ogg', duration: 1.002,
                                             encoded_date: '2020-02-27T18:23:48+00:00' },
                                           [{ part_type: 'audio', part_id: '28470', order: nil, format: 'Vorbis',
-                                             audio_metadata: { channels: '1', sampling_rate: 44_100, is_silent: false,
+                                             audio_metadata: { channels: '1', sampling_rate: 44_100,
+                                                               mean_volume: -24.2, max_volume: -4.7,
                                                                stream_size: 10_020 },
                                              video_metadata: nil, other_metadata: nil }]])
           expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', filepath)
@@ -129,11 +130,11 @@ RSpec.describe AvCharacterizerService do
         context 'when no audio track is detected by ffprobe' do
           let(:track_info) { '' }
 
-          it 'indicates the audio is silent and does not run ffmpeg command' do
+          it 'does not record the volume levels' do
             expect(characterization).to eq([{ audio_count: 1, file_extension: 'ogg', format: 'Ogg', duration: 1.002,
                                               encoded_date: '2020-02-27T18:23:48+00:00' },
                                             [{ part_type: 'audio', part_id: '28470', order: nil, format: 'Vorbis',
-                                               audio_metadata: { channels: '1', sampling_rate: 44_100, is_silent: true,
+                                               audio_metadata: { channels: '1', sampling_rate: 44_100,
                                                                  stream_size: 10_020 },
                                                video_metadata: nil, other_metadata: nil }]])
             expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', filepath)
@@ -142,7 +143,7 @@ RSpec.describe AvCharacterizerService do
           end
         end
 
-        context 'when an audio track is detected by ffprobe but the volume levels are low' do
+        context 'when a very quiet audio track is detected by ffprobe' do
           let(:volume_detect) do
             <<~VOLUME
               Lots of stuff here
@@ -153,11 +154,12 @@ RSpec.describe AvCharacterizerService do
             VOLUME
           end
 
-          it 'indicates the audio is silent' do
+          it 'records the volume levels' do
             expect(characterization).to eq([{ audio_count: 1, file_extension: 'ogg', format: 'Ogg', duration: 1.002,
                                               encoded_date: '2020-02-27T18:23:48+00:00' },
                                             [{ part_type: 'audio', part_id: '28470', order: nil, format: 'Vorbis',
-                                               audio_metadata: { channels: '1', sampling_rate: 44_100, is_silent: true,
+                                               audio_metadata: { channels: '1', sampling_rate: 44_100,
+                                                                 mean_volume: -45.2, max_volume: -31.7,
                                                                  stream_size: 10_020 },
                                                video_metadata: nil, other_metadata: nil }]])
             expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', filepath)
@@ -174,7 +176,8 @@ RSpec.describe AvCharacterizerService do
           expect(characterization).to eq([{ audio_count: 1, file_extension: 'ogg', format: 'Ogg', duration: 1.002,
                                             encoded_date: '2020-02-27T18:23:48+00:00' },
                                           [{ part_type: 'audio', part_id: '28470', order: nil, format: 'Vorbis',
-                                             audio_metadata: { channels: '1', sampling_rate: 44_100, is_silent: false,
+                                             audio_metadata: { channels: '1', sampling_rate: 44_100,
+                                                               mean_volume: -24.2, max_volume: -4.7,
                                                                stream_size: 10_020 },
                                              video_metadata: nil, other_metadata: nil }]])
           expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', filepath)
@@ -190,7 +193,8 @@ RSpec.describe AvCharacterizerService do
           expect(characterization).to eq([{ audio_count: 1, file_extension: 'ogg', format: 'Ogg', duration: 1.002,
                                             encoded_date: '2020-02-27T18:23:48+00:00' },
                                           [{ part_type: 'audio', part_id: '28470', order: nil, format: 'Vorbis',
-                                             audio_metadata: { channels: '1', sampling_rate: 44_100, is_silent: false,
+                                             audio_metadata: { channels: '1', sampling_rate: 44_100,
+                                                               mean_volume: -24.2, max_volume: -4.7,
                                                                stream_size: 10_020 },
                                              video_metadata: nil, other_metadata: nil }]])
           expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', filepath)
@@ -206,7 +210,8 @@ RSpec.describe AvCharacterizerService do
           expect(characterization).to eq([{ audio_count: 1, file_extension: 'ogg', format: 'Ogg', duration: 1.002,
                                             encoded_date: '2020-02-27T18:23:48+00:00' },
                                           [{ part_type: 'audio', part_id: '28470', order: nil, format: 'Vorbis',
-                                             audio_metadata: { channels: '1', sampling_rate: 44_100, is_silent: false,
+                                             audio_metadata: { channels: '1', sampling_rate: 44_100,
+                                                               mean_volume: -24.2, max_volume: -4.7,
                                                                stream_size: 10_020 },
                                              video_metadata: nil, other_metadata: nil }]])
           expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', filepath)
@@ -221,7 +226,8 @@ RSpec.describe AvCharacterizerService do
         it 'returns av_metadata and track metadata' do
           expect(characterization).to eq([{ audio_count: 1, file_extension: 'ogg', format: 'Ogg', duration: 1.002 },
                                           [{ part_type: 'audio', part_id: '28470', order: nil, format: 'Vorbis',
-                                             audio_metadata: { channels: '1', sampling_rate: 44_100, is_silent: false,
+                                             audio_metadata: { channels: '1', sampling_rate: 44_100,
+                                                               mean_volume: -24.2, max_volume: -4.7,
                                                                stream_size: 10_020 },
                                              video_metadata: nil, other_metadata: nil }]])
           expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', filepath)
@@ -317,7 +323,8 @@ RSpec.describe AvCharacterizerService do
                                                              frame_rate: 29.97, standard: 'NTSC' },
                                            other_metadata: nil },
                                          { part_type: 'audio', part_id: '2', order: 1, format: 'Opus',
-                                           audio_metadata: { codec_id: 'A_OPUS', is_silent: false, channels: '2',
+                                           audio_metadata: { codec_id: 'A_OPUS', channels: '2',
+                                                             mean_volume: -24.2, max_volume: -4.7,
                                                              sampling_rate: 48_000, bit_depth: 32 },
                                            video_metadata: nil, other_metadata: nil }]])
         expect(Open3).to have_received(:capture2e).with('mediainfo', '-f', '--Output=JSON', filepath)
@@ -408,6 +415,80 @@ RSpec.describe AvCharacterizerService do
 
       it 'raises' do
         expect { characterization }.to raise_error(AvCharacterizerService::Error)
+      end
+    end
+  end
+
+  describe '#audio_track?' do
+    let(:filepath) { 'test.mp3' }
+
+    context 'when file has an audio track' do
+      it 'returns true' do
+        expect(service.send(:audio_track?, filepath)).to be true
+      end
+    end
+
+    context 'when file has no audio track' do
+      let(:track_info) { '' }
+
+      it 'returns false' do
+        expect(service.send(:audio_track?, filepath)).to be false
+      end
+    end
+
+    context 'when ffprobe fails' do
+      let(:track_info) { 'error output' }
+      let(:status) { instance_double(Process::Status, success?: false, exitstatus: 1) }
+
+      it 'raises an error' do
+        expect { service.send(:audio_track?, filepath) }.to raise_error(AvCharacterizerService::Error)
+      end
+    end
+  end
+
+  describe '#compute_volume_levels' do
+    let(:filepath) { 'test.mp3' }
+
+    context 'when ffmpeg returns volume data successfully' do
+      let(:volume_detect) do
+        <<~VOLUME
+          [Parsed_volumedetect_0 @ 0x6000012f00b0] n_samples: 28525216
+          [Parsed_volumedetect_0 @ 0x6000012f00b0] mean_volume: -24.2 dB
+          [Parsed_volumedetect_0 @ 0x6000012f00b0] max_volume: -4.7 dB
+        VOLUME
+      end
+
+      it 'returns hash with mean and max volume levels' do
+        expect(service.send(:compute_volume_levels, filepath)).to eq(
+          mean_volume: -24.2,
+          max_volume: -4.7
+        )
+        expect(Open3).to have_received(:capture2e).with(ffmpeg_command)
+      end
+    end
+
+    context 'when ffmpeg returns volume data that cannot be parsed' do
+      let(:volume_detect) do
+        <<~VOLUME
+          Nothing but total nonsense returned
+        VOLUME
+      end
+
+      it 'returns hash with mean and max volume levels set to nil' do
+        expect(service.send(:compute_volume_levels, filepath)).to eq(
+          mean_volume: nil,
+          max_volume: nil
+        )
+        expect(Open3).to have_received(:capture2e).with(ffmpeg_command)
+      end
+    end
+
+    context 'when ffmpeg command fails' do
+      let(:status) { instance_double(Process::Status, success?: false, exitstatus: 1) }
+      let(:volume_detect) { 'error output' }
+
+      it 'raises an error' do
+        expect { service.send(:compute_volume_levels, filepath) }.to raise_error(AvCharacterizerService::Error)
       end
     end
   end


### PR DESCRIPTION
# Why was this change made? 🤔

Part of https://github.com/sul-dlss/common-accessioning/issues/1436
And goes with https://github.com/sul-dlss/common-accessioning/pull/1439

This adds extra metadata to media files so we can know when an audio track is mostly silent, which can be useful when deciding if captioning is needed.

Also updates the README to match the current API

~~HOLD: We first need to ensure ffmpeg is installed on all  tech metadata servers for this to work.  See https://github.com/sul-dlss/puppet/pull/11613 and https://github.com/sul-dlss/puppet/pull/11622~~

# How was this change tested? 🤨

Specs
QA server