### PR TITLE
midi files cannot run ffprobe

### DIFF
--- a/app/services/av_characterizer_service.rb
+++ b/app/services/av_characterizer_service.rb
@@ -82,7 +82,7 @@ class AvCharacterizerService
       metadata[:sampling_rate] = track['SamplingRate'].to_i if track['SamplingRate'].present?
       metadata[:bit_depth] = track['BitDepth'].to_i if track['BitDepth'].present?
       metadata[:stream_size] = track['StreamSize'].to_i if track['StreamSize'].present?
-      if audio_track?(filepath) # if the audio track exists, get the volume levels
+      if audio_track?(filepath, part[:format]) # if the audio track exists, get the volume levels
         volume_levels = compute_volume_levels(filepath)
         metadata[:mean_volume] = volume_levels[:mean_volume]
         metadata[:max_volume] = volume_levels[:max_volume]
@@ -132,7 +132,9 @@ class AvCharacterizerService
     }
   end
 
-  def audio_track?(filepath)
+  def audio_track?(filepath, format)
+    return false if format == 'MIDI' # MIDI files do not have audio tracks and will cause ffprobe to throw an error
+
     command = "ffprobe -i #{filepath.shellescape} -show_streams -select_streams a -loglevel error"
     output, status = Open3.capture2e(command)
 

--- a/spec/services/av_characterizer_service_spec.rb
+++ b/spec/services/av_characterizer_service_spec.rb
@@ -421,10 +421,11 @@ RSpec.describe AvCharacterizerService do
 
   describe '#audio_track?' do
     let(:filepath) { 'test.mp3' }
+    let(:format) { 'MPEG Audio' }
 
     context 'when file has an audio track' do
       it 'returns true' do
-        expect(service.send(:audio_track?, filepath)).to be true
+        expect(service.send(:audio_track?, filepath, format)).to be true
       end
     end
 
@@ -432,7 +433,16 @@ RSpec.describe AvCharacterizerService do
       let(:track_info) { '' }
 
       it 'returns false' do
-        expect(service.send(:audio_track?, filepath)).to be false
+        expect(service.send(:audio_track?, filepath, format)).to be false
+      end
+    end
+
+    context 'when it is a MIDI file' do
+      let(:filepath) { 'test.mid' }
+      let(:format) { 'MIDI' }
+
+      it 'returns false' do
+        expect(service.send(:audio_track?, filepath, format)).to be false
       end
     end
 
@@ -441,7 +451,7 @@ RSpec.describe AvCharacterizerService do
       let(:status) { instance_double(Process::Status, success?: false, exitstatus: 1) }
 
       it 'raises an error' do
-        expect { service.send(:audio_track?, filepath) }.to raise_error(AvCharacterizerService::Error)
+        expect { service.send(:audio_track?, filepath, format) }.to raise_error(AvCharacterizerService::Error)
       end
     end
   end


### PR DESCRIPTION
# Why was this change made? 🤔

To deal with https://app.honeybadger.io/projects/68956/faults/116182663, discovered when re-running technical metadata for all media items in stage after merging https://github.com/sul-dlss/technical-metadata-service/pull/572 which adds volume detection for files with audio tracks.

The issue is that MIDI files are audio files, but they do not have a traditional audio track, so running ffprobe on them will throw an exception.  This detects if the file is MIDI and indicates that no further processing on volume levels can be done.

# How was this change tested? 🤨

Updated spec
Localhost



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



