### PR TITLE
deal with invalid bytes in output

### DIFF
--- a/app/services/av_characterizer_service.rb
+++ b/app/services/av_characterizer_service.rb
@@ -151,7 +151,7 @@ class AvCharacterizerService
 
     raise Error, "Getting ffmpeg volume detection returned #{status.exitstatus}: #{output}" unless status.success?
 
-    split_output = output.split("\n")
+    split_output = output.scrub('').split("\n")
     { max_volume: ff_mpeg_content_parse(split_output.grep(/max_volume/)[0]),
       mean_volume: ff_mpeg_content_parse(split_output.grep(/mean_volume/)[0]) }
   end


### PR DESCRIPTION
# Why was this change made? 🤔

To deal with errors like this when characterizing media technical metadata: https://app.honeybadger.io/projects/68956/faults/116472334/01JJ3ABJN17AVZD894555EG8JH?page=0

Essentially, the output of ffprobe seems to sometimes contain invalid UTF-8 characters, so just remove them before trying to do the split on the output.

I verified on the rails console this worked on a file that is currently failing (and also worked on a file that was previously working fine).

# How was this change tested? 🤨

Rails console and existing specs