### PR TITLE
Remove explicit dependency on spring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,12 +39,6 @@ group :development, :test do
   gem 'simplecov', '~> 0.21'
 end
 
-group :development do
-  gem 'listen', '~> 3.7'
-  gem 'spring' # speeds up rails development by keeping your application running in the background.
-  gem 'spring-watcher-listen', '~> 2.0.0'
-end
-
 group :deployment do
   gem 'capistrano-passenger', require: false
   gem 'capistrano-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,9 +162,6 @@ GEM
       net-http (>= 0.5.0)
     faraday-retry (2.2.1)
       faraday (~> 2.0)
-    ffi (1.17.1)
-    ffi (1.17.1-x86_64-darwin)
-    ffi (1.17.1-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
     honeybadger (5.26.2)
@@ -189,9 +186,6 @@ GEM
     jwt (2.10.1)
       base64
     language_server-protocol (3.17.0.3)
-    listen (3.9.0)
-      rb-fsevent (~> 0.10, >= 0.10.3)
-      rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.6.5)
     loofah (2.24.0)
       crass (~> 1.0.2)
@@ -298,9 +292,6 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
-    rb-fsevent (0.11.2)
-    rb-inotify (0.11.1)
-      ffi (~> 1.0)
     rdoc (6.11.0)
       psych (>= 4.0.0)
     redis (4.8.1)
@@ -373,10 +364,6 @@ GEM
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
     smart_properties (1.17.0)
-    spring (2.1.1)
-    spring-watcher-listen (2.0.1)
-      listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
     sshkit (1.23.2)
       base64
       net-scp (>= 1.1.2)
@@ -421,7 +408,6 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   jwt
-  listen (~> 3.7)
   moab-versioning (~> 6.0)
   okcomputer
   pg
@@ -441,8 +427,6 @@ DEPENDENCIES
   rubocop-rspec_rails
   sidekiq (~> 7.0)
   simplecov (~> 0.21)
-  spring
-  spring-watcher-listen (~> 2.0.0)
   turbo-rails
 
 BUNDLED WITH


### PR DESCRIPTION
Do not need it, do not use it.

# Why was this change made? 🤔



# How was this change tested? 🤨

⚡ ⚠ If this change consumes from or writes to other services (including shared file systems), ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test) on stage as it exercises this service*** and/or test in [stage|qa] environment, in addition to specs.  ***You will need to confirm that technical metadata was correctly created for the test, as it is a background job kicked off by a common-accessioning step.***⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



