### PR TITLE
Remove explicit one-time key setup

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -3,5 +3,4 @@
 server 'dor-techmd-prod-a.stanford.edu', user: 'techmd', roles: %w[web app db worker]
 server 'dor-techmd-worker-prod-a.stanford.edu', user: 'techmd', roles: %w[app worker]
 
-Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -3,5 +3,4 @@
 server 'dor-techmd-qa-a.stanford.edu', user: 'techmd', roles: %w[web app db worker]
 server 'dor-techmd-worker-qa-a.stanford.edu', user: 'techmd', roles: %w[app worker]
 
-Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -3,5 +3,4 @@
 server 'dor-techmd-stage-a.stanford.edu', user: 'techmd', roles: %w[web app db worker]
 server 'dor-techmd-worker-stage-a.stanford.edu', user: 'techmd', roles: %w[app worker]
 
-Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'


### PR DESCRIPTION
This line has been a no-op since dlss-capistrano 5.2.0. Setting up the one-time key is done automatically in dlss-capistrano now.