### PR TITLE
remove deprecated platforms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'dor-services-client'
 gem 'moab-versioning', '~> 6.0'
 
 group :development, :test do
-  gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'byebug'
   gem 'erb_lint', require: false
   gem 'rexml' # required by erb_lint, can be removed when fixed, see https://github.com/Shopify/erb_lint/issues/371
   gem 'rspec_junit_formatter'


### PR DESCRIPTION
# Why was this change made? 🤔

`[DEPRECATED] Platform :mingw, :x64_mingw is deprecated. Please use platform :windows instead.`


# How was this change tested? 🤨

⚡ ⚠ If this change consumes from or writes to other services (including shared file systems), ***run [integration test create_preassembly_image_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test) on stage as it exercises this service*** and/or test in [stage|qa] environment, in addition to specs.  ***You will need to confirm that technical metadata was correctly created for the test, as it is a background job kicked off by a common-accessioning step.***⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



