### PR TITLE
Fix local bundle install

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,6 +278,8 @@ GEM
     nokogiri (1.19.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.19.2-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.19.2-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.2-x86_64-linux-gnu)
@@ -296,6 +298,7 @@ GEM
     patience_diff (1.2.0)
       optimist (~> 3.0)
     pg (1.6.3)
+    pg (1.6.3-arm64-darwin)
     pg (1.6.3-x86_64-darwin)
     pg (1.6.3-x86_64-linux)
     pp (0.6.3)
@@ -467,6 +470,7 @@ GEM
     zeitwerk (2.7.5)
 
 PLATFORMS
+  arm64-darwin-24
   ruby
   x86_64-darwin-19
   x86_64-linux


### PR DESCRIPTION
I was unable to get `bundle install` to complete without barfing on nokogiri locally without:

```
# Lock to the arm64 binary
bundle lock --add-platform arm64-darwin-24
bundle install
```

Feel free to close this without merging if we want to keep it out of the repo, but I suspect others may hit this. TechMd is just one of those repos we rarely deal with locally.